### PR TITLE
noise wrapper alternative

### DIFF
--- a/test/analyticless_convergence_tests.jl
+++ b/test/analyticless_convergence_tests.jl
@@ -14,8 +14,8 @@ test_setup = Dict(:alg=>Vern9(),:reltol=>1e-25,:abstol=>1e-25)
 sim1 = analyticless_test_convergence(dts,prob,Tsit5(),test_setup)
 sim2 = analyticless_test_convergence(dts,prob,Vern9(),test_setup)
 
-@test sim1.𝒪est[:final]-5 < 0.2
-@test sim2.𝒪est[:final]-9 < 0.2
+@test abs(sim1.𝒪est[:final]-5) < 0.2
+@test abs(sim2.𝒪est[:final]-9) < 0.2
 
 function f2(du,u,p,t)
   du .= 1.01u
@@ -23,12 +23,19 @@ end
 function g2(du,u,p,t)
   du .= 1.01u
 end
-prob = SDEProblem(f2,g2,[1.0;1.0],(0.0,10.0))
+prob = SDEProblem(f2,g2,[1.0;1.0],(0.0,1.0))
 
 using StochasticDiffEq
 
-dts = (1/2).^(6:-1:3)
+dts = (1/2).^(7:-1:3)
 test_dt = 1/2^8
 Random.seed!(100)
-sim1 = analyticless_test_convergence(dts,prob,SRIW1(),test_dt,trajectories=400)
-@test sim1.𝒪est[:final]-1.5 < 0.3
+sim1 = analyticless_test_convergence(dts,prob,SRIW1(),test_dt,trajectories=100)
+@test abs(sim1.𝒪est[:final]-1.5) < 0.4
+@show sim1.𝒪est[:final]
+
+dts = (1/2).^(7:-1:4)
+test_dt = 1/2^8
+sim2 = analyticless_test_convergence(dts,prob,SRIW1(),test_dt,trajectories=100, use_noise_grid=false)
+@test abs(sim2.𝒪est[:final]-1.5) < 0.3
+@show sim2.𝒪est[:final]


### PR DESCRIPTION
Without the NoiseWrapper alternative the convergence simulations look like case1.pdf.
The final slope is then a bad estimate and basically just depend on how much dts are used. 

The lines in this PR which actually solve the problems are:
```
for i in 1:length(dts)
        W1 = NoiseWrapper(_sol.W)
        _prob = remake(prob,u0=prob.u0,p=prob.p,tspan=prob.tspan,noise=W1,noise_rate_prototype = prob.noise_rate_prototype)
```
which repeat the noise for each dt.
Then the plots look like case2.pdf .

This also fixes the NaN values obtained in:
https://github.com/SciML/StochasticDiffEq.jl/pull/317/
for `EM()` and `EulerHeun()`.

[case1.pdf](https://github.com/SciML/DiffEqDevTools.jl/files/4650575/case1.pdf)
[case2.pdf](https://github.com/SciML/DiffEqDevTools.jl/files/4650577/case2.pdf)
