### PR TITLE
Work Precision Set for EnsembleProblem

### DIFF
--- a/test/analyticless_convergence_tests.jl
+++ b/test/analyticless_convergence_tests.jl
@@ -40,6 +40,44 @@ sim2 = analyticless_test_convergence(dts,prob,SRIW1(),test_dt,trajectories=100, 
 @test abs(sim2.𝒪est[:final]-1.5) < 0.3
 @show sim2.𝒪est[:final]
 
+
+# EnsembleProblem
+
+function prob_func(prob, i, repeat)
+    remake(prob,seed=seeds[i])
+end
+
+u₀ = [1.0,1.0]
+function f2!(du,u,p,t)
+  du[1] = -273//512*u[1]
+  du[2] = -1//160*u[1]-(-785//512+sqrt(2)/8)*u[2]
+end
+function g2!(du,u,p,t)
+  du[1,1] = 1//4*u[1]
+  du[1,2] = 1//16*u[1]
+  du[2,1] = (1-2*sqrt(2))/4*u[1]
+  du[2,2] = 1//10*u[1]+1//16*u[2]
+end
+dts = 1 .//2 .^(3:-1:0)
+tspan = (0.0,3.0)
+
+h2(z) = z^2 # but apply it only to u[1]
+
+prob = SDEProblem(f2!,g2!,u₀,tspan,noise_rate_prototype=zeros(2,2))
+
+numtraj = Int(1e5)
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+ensemble_prob = EnsembleProblem(prob;
+        output_func = (sol,i) -> (h2(sol[end][1]),false),
+        prob_func = prob_func
+        )
+sim = test_convergence(dts,ensemble_prob,DRI1(),save_everystep=false,trajectories=numtraj,save_start=false,adaptive=false,weak_timeseries_errors=false,weak_dense_errors=false,expected_value=exp(-3.0))
+
+@test abs(sim.𝒪est[:weak_final]-2.0) < 0.3
+@show sim.𝒪est[:weak_final]
+
 ### SDDE
 
 function hayes_modelf(du,u,h,p,t)

--- a/test/analyticless_stochastic_wp.jl
+++ b/test/analyticless_stochastic_wp.jl
@@ -37,3 +37,68 @@ se2 = get_sample_errors(prob2,setups[1],test_dt,appxsol_setup = appxsol_setup,
                         numruns=[5,10,25,50,100],solution_runs=20)
 
 @test all(se[1:5]-se2 .< 1e-1)
+
+
+# Ensemble Problem with non-commutative noise process
+
+function prob_func(prob, i, repeat)
+    remake(prob,seed=seeds[i])
+end
+
+u₀ = [1.0,1.0]
+function f2!(du,u,p,t)
+  du[1] = -273//512*u[1]
+  du[2] = -1//160*u[1]-(-785//512+sqrt(2)/8)*u[2]
+  return nothing
+end
+function g2!(du,u,p,t)
+  du[1,1] = 1//4*u[1]
+  du[1,2] = 1//16*u[1]
+  du[2,1] = (1-2*sqrt(2))/4*u[1]
+  du[2,2] = 1//10*u[1]+1//16*u[2]
+  return nothing
+end
+dts = 1 .//2 .^(3:-1:0)
+tspan = (0.0,3.0)
+
+h2(z) = z^2 # but apply it only to u[1]
+
+prob = SDEProblem(f2!,g2!,u₀,tspan,noise_rate_prototype=zeros(2,2))
+
+numtraj = Int(1e5)
+seed = 100
+Random.seed!(seed)
+seeds = rand(UInt, numtraj)
+ensemble_prob = EnsembleProblem(prob;
+        output_func = (sol,i) -> (h2(sol[end][1]),false),
+        prob_func = prob_func
+        )
+
+reltols = 1.0 ./ 4.0 .^ (1:4)
+abstols = reltols#[0.0 for i in eachindex(reltols)]
+setups = [
+        Dict(:alg=>EM(),:dts=>dts),
+        Dict(:alg=>SimplifiedEM(),:dts=>dts),
+        Dict(:alg=>DRI1(),:dts=>dts, :adaptive=>false)
+        ]
+test_dt = 1//1000
+appxsol_setup = Dict(:alg=>EM(), :dt=>test_dt)
+
+# without analytical expectation value
+wp1 = @time WorkPrecisionSet(ensemble_prob,abstols,reltols,setups,test_dt;
+                            maxiters = 1e7,
+                            verbose=false,save_everystep=false, save_start=false,
+                            appxsol_setup = appxsol_setup,
+                            trajectories=numtraj, error_estimate=:weak_final)
+
+# with analytical expectation value
+wp2 = @time WorkPrecisionSet(ensemble_prob,abstols,reltols,setups,test_dt;
+                            maxiters = 1e7,
+                            verbose=false,save_everystep=false, save_start=false,
+                            appxsol_setup = appxsol_setup,expected_value=exp(-3.0),
+                            trajectories=numtraj, error_estimate=:weak_final)
+
+err1 = [wp1.wps[i].errors for i=1:length(setups)]
+err2 = [wp2.wps[i].errors for i=1:length(setups)]
+
+@test isapprox(err1, err2, atol=1e-4)


### PR DESCRIPTION
This PR adds the dispatch to compute a WorkPrecisionSet for weak errors for a ensemble problem. 
For the sake of completeness, I also added a test for test_convergence from PR #74 .

The work precision plot for the test in  test/analyticless_stochastic_wp.jl looks as follows:
![WorkPrecision](https://user-images.githubusercontent.com/42201748/90391969-512b6e00-e08e-11ea-9723-67b28921bca6.png)
