### PR TITLE
weak timeseries error for EnsembleProb

### DIFF
--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -442,8 +442,15 @@ function WorkPrecisionSet(prob::AbstractEnsembleProblem,abstols,reltols,setups,t
 
   if error_estimate ∈ WEAK_ERRORS
     if expected_value != nothing
-      errors = [[LinearAlgebra.norm(Statistics.mean(solutions[i,j].u .- expected_value))
-        for i in 1:M] for j in 1:N]
+      if error_estimate == :weak_final
+        errors = [[LinearAlgebra.norm(Statistics.mean(solutions[i,j].u .- expected_value))
+          for i in 1:M] for j in 1:N]
+      elseif error_estimate == :weak_l2
+        errors = [[LinearAlgebra.norm(Statistics.mean(solutions[i,j] .- expected_value))
+          for i in 1:M] for j in 1:N]
+      else
+        error("Error estimate $error_estimate is not implemented yet.")      
+      end
     else
       sol = solve(prob,appxsol_setup[:alg],ensemblealg;kwargs...,appxsol_setup...,
           timeseries_errors=false,dense_errors = false,trajectories=Int(trajectories))

--- a/src/convergence.jl
+++ b/src/convergence.jl
@@ -75,10 +75,20 @@ function test_convergence(dts::AbstractArray,
 
   else
     additional_errors = Dict()
-    additional_errors[:weak_final] = []
+    if length(expected_value) == 1 || typeof(expected_value) <: Number
+      additional_errors[:weak_final] = []
+    else
+      additional_errors[:weak_l2] = []
+    end
     for sol in _solutions
-      weak_final = LinearAlgebra.norm(Statistics.mean(sol.u .- expected_value))
-      push!(additional_errors[:weak_final],weak_final)
+      if length(expected_value) == 1 || typeof(expected_value) <: Number
+        weak_final = LinearAlgebra.norm(Statistics.mean(sol.u .- expected_value))
+        push!(additional_errors[:weak_final],weak_final)
+      else
+        weak_l2 = LinearAlgebra.norm(Statistics.mean(sol .- expected_value))
+        push!(additional_errors[:weak_l2],weak_l2)
+      end
+
     end
     solutions = _solutions
   end


### PR DESCRIPTION
This allows to pass an array as `expected_value` (to encode the time evolution of the expected value) such that one can also compute the convergence plot and the work precision diagram for `weak_l2` errors in addition to the `weak_final` errors.
