### PR TITLE
Better default name for `MethodOfSteps` algorithms

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqDevTools"
 uuid = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.31.0"
+version = "2.31.1"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/src/DiffEqDevTools.jl
+++ b/src/DiffEqDevTools.jl
@@ -8,7 +8,7 @@ using Statistics
 
 import Base: length
 
-import DiffEqBase: AbstractODEProblem, AbstractDDEProblem,
+import DiffEqBase: AbstractODEProblem, AbstractDDEProblem, AbstractDDEAlgorithm,
                    AbstractODESolution, AbstractRODEProblem, AbstractSDEProblem,
                    AbstractSDDEProblem, AbstractEnsembleProblem,
                    AbstractDAEProblem, @def, ConvergenceSetup, DEAlgorithm,

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -4,7 +4,9 @@ using Statistics
 # Workaround for `MethodOfSteps` algorithms, otherwise they are all called "MethodOfSteps"
 # Ideally this would be a trait (in SciMLBase?), so packages could implement it
 _default_name(alg) = __default_name(alg)
-_default_name(alg::AbstractDDEAlgorithm) = isdefined(alg, :alg) ? _default_name(alg.alg) : __default_name(alg)
+function _default_name(alg::AbstractDDEAlgorithm)
+    isdefined(alg, :alg) ? _default_name(alg.alg) : __default_name(alg)
+end
 __default_name(alg) = string(nameof(typeof(alg)))
 
 ## Shootouts

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -1,4 +1,12 @@
 using Statistics
+
+# Default names of algorithms:
+# Workaround for `MethodOfSteps` algorithms, otherwise they are all called "MethodOfSteps"
+# Ideally this would be a trait (in SciMLBase?), so packages could implement it
+_default_name(alg) = __default_name(alg)
+_default_name(alg::AbstractDDEAlgorithm) = isdefined(alg, :alg) ? _default_name(alg.alg) : __default_name(alg)
+__default_name(alg) = string(nameof(typeof(alg)))
+
 ## Shootouts
 
 mutable struct Shootout
@@ -39,7 +47,7 @@ function Shootout(prob, setups; appxsol = nothing, names = nothing, error_estima
     timeseries_errors = error_estimate ∈ TIMESERIES_ERRORS
     dense_errors = error_estimate ∈ DENSE_ERRORS
     if names === nothing
-        names = [string(nameof(typeof(setup[:alg]))) for setup in setups]
+        names = [_default_name(setup[:alg]) for setup in setups]
     end
     for i in eachindex(setups)
         sol = solve(prob, setups[i][:alg]; timeseries_errors = timeseries_errors,
@@ -107,7 +115,7 @@ function ShootoutSet(probs, setups; probaux = nothing,
     shootouts = Vector{Shootout}(undef, N)
     winners = Vector{String}(undef, N)
     if names === nothing
-        names = [string(nameof(typeof(setup[:alg]))) for setup in setups]
+        names = [_default_name(setup[:alg]) for setup in setups]
     end
     if probaux === nothing
         probaux = Vector{Dict{Symbol, Any}}(undef, N)
@@ -272,7 +280,7 @@ function WorkPrecisionSet(prob,
     @assert names === nothing || length(setups) == length(names)
     wps = Vector{WorkPrecision}(undef, N)
     if names === nothing
-        names = [string(nameof(typeof(setup[:alg]))) for setup in setups]
+        names = [_default_name(setup[:alg]) for setup in setups]
     end
     for i in 1:N
         print_names && println(names[i])
@@ -351,7 +359,7 @@ function WorkPrecisionSet(prob::AbstractRODEProblem, abstols, reltols, setups,
     times = Array{Float64}(undef, M, N)
     tmp_solutions = Array{Any}(undef, numruns_error, M, N)
     if names === nothing
-        names = [string(nameof(typeof(setup[:alg]))) for setup in setups]
+        names = [_default_name(setup[:alg]) for setup in setups]
     end
     time_tmp = Vector{Float64}(undef, numruns)
 
@@ -434,7 +442,7 @@ function WorkPrecisionSet(prob::AbstractEnsembleProblem, abstols, reltols, setup
     times = Array{Float64}(undef, M, N)
     solutions = Array{Any}(undef, M, N)
     if names === nothing
-        names = [string(nameof(typeof(setup[:alg]))) for setup in setups]
+        names = [_default_name(setup[:alg]) for setup in setups]
     end
     time_tmp = Vector{Float64}(undef, numruns)
 

--- a/test/benchmark_tests.jl
+++ b/test/benchmark_tests.jl
@@ -39,6 +39,7 @@ shoot = Shootout(prob, setups, dt = 1 / 2^(4))
 #show(shoot)
 #println(shoot)
 shoot[end]
+@test shoot.names == ["RK4", "Euler", "BS3", "Midpoint", "BS5", "DP5"]
 
 set = ShootoutSet(probs, setups; dt = 1 / 2^(4))
 
@@ -46,7 +47,7 @@ set = ShootoutSet(probs, setups; dt = 1 / 2^(4))
 #println(set[:])
 set[end]
 set[1][:]
-@test set.names == ["RK4", "Midpoint"]
+@test all(x -> x.names == ["RK4", "Euler", "BS3", "Midpoint", "BS5", "DP5"], set)
 
 ## WorkPrecision Tests
 println("WorkPrecision Tests")
@@ -66,7 +67,7 @@ wp_set[end]
 #println(wp_set)
 #show(wp_set)
 @test (minimum(diff(wp_set[2].errors) .== 0)) # The errors for a fixed timestep method should be constant
-@test wp_set.names == ["RK4", "Midpoint"]
+@test wp_set.names == ["RK4", "Euler", "BS3", "Midpoint", "BS5", "DP5"]
 
 prob = prob_ode_2Dlinear
 

--- a/test/benchmark_tests.jl
+++ b/test/benchmark_tests.jl
@@ -46,6 +46,7 @@ set = ShootoutSet(probs, setups; dt = 1 / 2^(4))
 #println(set[:])
 set[end]
 set[1][:]
+@test set.names == ["RK4", "Midpoint"]
 
 ## WorkPrecision Tests
 println("WorkPrecision Tests")
@@ -65,6 +66,7 @@ wp_set[end]
 #println(wp_set)
 #show(wp_set)
 @test (minimum(diff(wp_set[2].errors) .== 0)) # The errors for a fixed timestep method should be constant
+@test wp_set.names == ["RK4", "Midpoint"]
 
 prob = prob_ode_2Dlinear
 
@@ -81,6 +83,7 @@ test_sol1 = TestSolution(sol)
 println("Test DP5 and Tsit5")
 wp = WorkPrecisionSet(prob, abstols, reltols, setups; save_everystep = false)
 
+@test wp.names == ["DP5", "Tsit5"]
 @test length(wp[1]) == 5
 @test length(wp[2]) == 4
 
@@ -102,6 +105,7 @@ setups = [Dict(:alg => DP5())
 println("Test DP5, Tsit5, and Vern6")
 wp = WorkPrecisionSet(prob, abstols, reltols, setups; appxsol = test_sol,
                       save_everystep = false, numruns = 20, maxiters = 10000)
+@test wp.names == ["DP5", "Tsit5", "Vern6"]
 
 # Dual Problem
 
@@ -112,8 +116,10 @@ setups = [Dict(:alg => DP5())
 println("Test DP5, Tsit5, and Vern6")
 wp = WorkPrecisionSet(probs, abstols, reltols, setups; appxsol = [test_sol, nothing],
                       save_everystep = false, numruns = 20, maxiters = 10000)
+@test wp.names == ["DP5", "Tsit5", "Vern6"]
 wp = WorkPrecisionSet(probs, abstols, reltols, setups; appxsol = [test_sol, test_sol1],
                       save_everystep = false, numruns = 20, maxiters = 10000)
+@test wp.names == ["DP5", "Tsit5", "Vern6"]
 
 # Dual DAE Problems
 function rober(du, u, p, t)
@@ -147,6 +153,7 @@ setups = [Dict(:alg => Rodas5())
           Dict(:alg => DFBDF(), :prob_choice => 2)]
 wp = WorkPrecisionSet(probs, abstols, reltols, setups; appxsol = [ode_ref_sol, dae_ref_sol],
                       save_everystep = false, numruns = 20, maxiters = 10000)
+@test wp.names == ["Rodas5", "DFBDF"]
 
 # DDE problem
 prob = prob_dde_constant_1delay_ip
@@ -160,8 +167,8 @@ test_sol = TestSolution(sol)
 setups = [Dict(:alg => MethodOfSteps(BS3()))
           Dict(:alg => MethodOfSteps(Tsit5()))]
 println("Test MethodOfSteps BS3 and Tsit5")
-#Travis compile time issue
-#wp = WorkPrecisionSet(prob, abstols, reltols, setups; appxsol = test_sol)
+wp = WorkPrecisionSet(prob, abstols, reltols, setups; appxsol = test_sol)
+@test wp.names == ["BS3", "Tsit5"]
 println("DDE Done")
 
 __f(u, p, t) = 1.01 * u
@@ -172,3 +179,4 @@ sol = solve(prob, Rodas4(), reltol = 1e-8, abstol = 1e-8)
 setups = [Dict(:alg => RadauIIA5()),
     Dict(:alg => RosShamp4())]
 shoot = Shootout(prob, setups; appxsol = TestSolution(sol))
+@test shoot.names == ["RadauIIA5", "RosShamp4"]

--- a/test/benchmark_tests.jl
+++ b/test/benchmark_tests.jl
@@ -47,7 +47,7 @@ set = ShootoutSet(probs, setups; dt = 1 / 2^(4))
 #println(set[:])
 set[end]
 set[1][:]
-@test all(x -> x.names == ["RK4", "Euler", "BS3", "Midpoint", "BS5", "DP5"], set)
+@test all(x -> x.names == ["RK4", "Euler", "BS3", "Midpoint", "BS5", "DP5"], set.shootouts)
 
 ## WorkPrecision Tests
 println("WorkPrecision Tests")


### PR DESCRIPTION
Currently, the default name for `MethodOfSteps` algorithms is `"MethodOfSteps"` and hence the `names` keyword argument always has to be specified (see e.g. https://benchmarks.sciml.ai/html/NonStiffDDE/Mackey_Glass_wpd.html). This is annoying, and I guess the name of the ODE algorithm would be a good default (as used in the benchmarks currently).

Unfortunately, the workaround is a bit ugly. I guess a better approach would be a trait in SciMLBase for (short) names that could use the default `string(nameof(typeof(alg)))` and be specialized in DelayDiffEq for `MethodOfSteps`.