### PR TITLE
Δt-convergence plot recipe for WorkPrecisionSet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.jl.*.cov
 *.jl.mem
 Manifest.toml
+
+# vscode
+.vscode
+.vscode/*

--- a/Project.toml
+++ b/Project.toml
@@ -35,7 +35,8 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SDEProblemLibrary = "c72e72a9-a271-4b2b-8966-303ed956772e"
 StochasticDelayDiffEq = "29a0d76e-afc8-11e9-03a4-eda52ae4b960"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DelayDiffEq", "DDEProblemLibrary", "ODEProblemLibrary", "SDEProblemLibrary", "OrdinaryDiffEq", "ParameterizedFunctions", "Random", "StochasticDiffEq", "StochasticDelayDiffEq", "Test"]
+test = ["DelayDiffEq", "DDEProblemLibrary", "ODEProblemLibrary", "SDEProblemLibrary", "OrdinaryDiffEq", "ParameterizedFunctions", "Random", "StochasticDiffEq", "StochasticDelayDiffEq", "Plots", "Test"]

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -37,7 +37,7 @@ end
     wp.errors, wp.times
 end
 
-@recipe function f(wp_set::WorkPrecisionSet; color=reshape(1:length(wp_set), 1, :), view=:benchmark)
+@recipe function f(wp_set::WorkPrecisionSet; view=:benchmark, color=nothing)
     if view == :benchmark
         seriestype --> :path
         linewidth --> 3
@@ -69,11 +69,14 @@ end
             push!(convs, exp(lc) * dts[end] .^ p)
         end
         names = wp_set.names[idts] .* map(p -> " (Δᵖ order p=$(round(p, sigdigits=2)))", ps)
+        if color === nothing
+            color = reshape(1:length(idts), 1, :)
+        end
         @series begin
             seriestype --> :path
             linestyle --> :dash
             linewidth --> 1
-            color --> permutedims(color[idts])
+            color --> color
             xscale --> :log10
             yscale --> :log10
             markersize --> 0
@@ -83,7 +86,7 @@ end
         @series begin
             seriestype --> :path
             linewidth --> 3
-            color --> permutedims(color[idts])
+            color --> color
             yguide --> "Error"
             xguide --> "Δt"
             xscale --> :log10

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -69,7 +69,8 @@ end
             push!(ps, p)
             push!(convs, exp(lc) * dts[end] .^ p)
         end
-        names = wp_set.names[idts] .* map(p -> " (Δᵖ order p=$(round(p, sigdigits=2)))", ps)
+        names = wp_set.names[idts] .*
+                map(p -> " (Δtᵖ order p=$(round(p, sigdigits=2)))", ps)
         if color === nothing
             color = reshape(1:length(idts), 1, :)
         end

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -37,22 +37,64 @@ end
     wp.errors, wp.times
 end
 
-@recipe function f(wp_set::WorkPrecisionSet)
-    seriestype --> :path
-    linewidth --> 3
-    yguide --> "Time (s)"
-    xguide --> "Error"
-    xscale --> :log10
-    yscale --> :log10
-    marker --> :auto
-    errors = Vector{Any}(undef, 0)
-    times = Vector{Any}(undef, 0)
-    for i in 1:length(wp_set)
-        push!(errors, wp_set[i].errors)
-        push!(times, wp_set[i].times)
+@recipe function f(wp_set::WorkPrecisionSet; color=reshape(1:length(wp_set), 1, :), view=:benchmark)
+    if view == :benchmark
+        seriestype --> :path
+        linewidth --> 3
+        yguide --> "Time (s)"
+        xguide --> "Error"
+        xscale --> :log10
+        yscale --> :log10
+        marker --> :auto
+        errors = Vector{Any}(undef, 0)
+        times = Vector{Any}(undef, 0)
+        for i in 1:length(wp_set)
+            push!(errors, wp_set[i].errors)
+            push!(times, wp_set[i].times)
+        end
+        label --> reshape(wp_set.names, 1, length(wp_set))
+        return errors, times
+    elseif view == :dt_convergence
+        idts =  filter(i -> haskey(wp_set.setups[i], :dts), 1:length(wp_set))
+        length(idts) > 0 || throw(ArgumentError("Convergence with respect to Δt requires runs with fixed time steps"))
+        dts = Vector{Any}(undef, 0)
+        errors = Vector{Any}(undef, 0)
+        ps = Vector{Any}(undef, 0)
+        convs = Vector{Any}(undef, 0)
+        for i in idts
+            push!(dts, wp_set.setups[i][:dts])
+            push!(errors, wp_set[i].errors)
+            lc, p = [one.(dts[end]) log.(dts[end])] \ log.(errors[end])
+            push!(ps, p)
+            push!(convs, exp(lc) * dts[end] .^ p)
+        end
+        names = wp_set.names[idts] .* map(p -> " (Δᵖ order p=$(round(p, sigdigits=2)))", ps)
+        @series begin
+            seriestype --> :path
+            linestyle --> :dash
+            linewidth --> 1
+            color --> permutedims(color[idts])
+            xscale --> :log10
+            yscale --> :log10
+            markersize --> 0
+            label --> nothing
+            return dts, convs
+        end
+        @series begin
+            seriestype --> :path
+            linewidth --> 3
+            color --> permutedims(color[idts])
+            yguide --> "Error"
+            xguide --> "Δt"
+            xscale --> :log10
+            yscale --> :log10
+            marker --> :auto
+            label --> reshape(names, 1, length(idts))
+            return dts, errors
+        end
+    else
+        throw(ArgumentError("view argument `$view` not implemented"))
     end
-    label --> reshape(wp_set.names, 1, length(wp_set))
-    errors, times
 end
 
 @recipe function f(tab::ODERKTableau; dx = 1 / 100, dy = 1 / 100, order_star = false,

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -37,7 +37,7 @@ end
     wp.errors, wp.times
 end
 
-@recipe function f(wp_set::WorkPrecisionSet; view=:benchmark, color=nothing)
+@recipe function f(wp_set::WorkPrecisionSet; view = :benchmark, color = nothing)
     if view == :benchmark
         seriestype --> :path
         linewidth --> 3
@@ -55,8 +55,9 @@ end
         label --> reshape(wp_set.names, 1, length(wp_set))
         return errors, times
     elseif view == :dt_convergence
-        idts =  filter(i -> haskey(wp_set.setups[i], :dts), 1:length(wp_set))
-        length(idts) > 0 || throw(ArgumentError("Convergence with respect to Δt requires runs with fixed time steps"))
+        idts = filter(i -> haskey(wp_set.setups[i], :dts), 1:length(wp_set))
+        length(idts) > 0 ||
+            throw(ArgumentError("Convergence with respect to Δt requires runs with fixed time steps"))
         dts = Vector{Any}(undef, 0)
         errors = Vector{Any}(undef, 0)
         ps = Vector{Any}(undef, 0)

--- a/test/plotrecipes_tests.jl
+++ b/test/plotrecipes_tests.jl
@@ -18,7 +18,8 @@ f_rode_lin_analytic = function (u₀, p, t)
 end
 
 tspan = (0.0, 10.0)
-prob = ODEProblem(ODEFunction(f_rode_lin, analytic = f_rode_lin_analytic), rand(10, 10), tspan)
+prob = ODEProblem(ODEFunction(f_rode_lin, analytic = f_rode_lin_analytic), rand(10, 10),
+                  tspan)
 
 abstols = 1.0 ./ 10.0 .^ (3:8)
 reltols = 1.0 ./ 10.0 .^ (0:5)

--- a/test/plotrecipes_tests.jl
+++ b/test/plotrecipes_tests.jl
@@ -20,6 +20,7 @@ end
 tspan = (0.0,10.0)
 prob = ODEProblem(ODEFunction(f2d,analytic=f2d_analytic),rand(10,10),tspan)
 
+
 abstols = 1.0 ./ 10.0 .^ (3:8)
 reltols = 1.0 ./ 10.0 .^ (0:5)
 
@@ -35,25 +36,28 @@ plt = @test_nowarn plot(wp)
 @test plt[1][2][:x] ≈ wp[2].errors
 @test plt[1][1][:label] == names[1]
 @test plt[1][2][:label] == names[2]
+@test_nowarn plot(wp, color=[1 2])
+@test_nowarn plot(wp, color=:blue)
 @test_throws ArgumentError plot(wp, view=:dt_convergence)
 
 dts = 1.0./2.0.^((1:length(reltols)) .+ 1)
 setups = [
     Dict(:alg=>Euler(),:dts=>dts)
     Dict(:alg=>Heun(),:dts=>dts)
-    Dict(:alg=>DP5(),:dts=>dts,:adaptive=>false)
     Dict(:alg=>Tsit5(),:dts=>dts,:adaptive=>false)
     Dict(:alg=>Tsit5())
 ]
-names = ["Euler", "Heun", "DP5 fixed step", "Tsit5 fixed step", "Tsit5 adaptive"]
+names = ["Euler", "Heun", "Tsit5 fixed step", "Tsit5 adaptive"]
 wp = WorkPrecisionSet(prob,abstols,reltols,setups,names=names,save_everystep=false,numruns=100)
 
 plt = @test_nowarn plot(wp)
-@test all(plt[1][i][:x] ≈ wp[i].errors for i in 1:5)
-@test all(plt[1][i][:label] == names[i] for i in 1:5)
+@test all(plt[1][i][:x] ≈ wp[i].errors for i in 1:4)
+@test all(plt[1][i][:label] == names[i] for i in 1:4)
 
 plt = @test_nowarn plot(wp, view=:dt_convergence, legend=:bottomright)
-@test all(plt[1][i][:x] == plt[1][i+4][:x] == dts == wp.setups[i][:dts] for i in 1:4)
-@test all(plt[1][i+4][:y] ≈ wp[i].errors for i in 1:4)
-@test all(startswith(plt[1][i+4][:label], names[i]) for i in 1:4)
-@test_throws BoundsError plt[1][9]
+@test all(plt[1][i][:x] == plt[1][i+3][:x] == dts == wp.setups[i][:dts] for i in 1:3)
+@test all(plt[1][i+3][:y] ≈ wp[i].errors for i in 1:3)
+@test all(startswith(plt[1][i+3][:label], names[i]) for i in 1:3)
+@test_throws BoundsError plt[1][7]
+@test_nowarn plot(wp, view=:dt_convergence, color=[:red :orange :green])
+@test_nowarn plot(wp, view=:dt_convergence, color=:lightblue, title="Δt Convergence")

--- a/test/plotrecipes_tests.jl
+++ b/test/plotrecipes_tests.jl
@@ -1,0 +1,59 @@
+using Test
+using OrdinaryDiffEq, DiffEqDevTools, Plots
+
+using Random
+Random.seed!(123)
+
+gr()
+
+# 2D Linear ODE
+function f2d(du, u, p, t)
+    @inbounds for i in eachindex(u)
+        du[i] = cos(t) * u[i]
+    end
+end
+
+function f2d_analytic(u₀, p, t)
+    u₀ * exp(sin(t))
+end
+
+tspan = (0.0,10.0)
+prob = ODEProblem(ODEFunction(f2d,analytic=f2d_analytic),rand(10,10),tspan)
+
+abstols = 1.0 ./ 10.0 .^ (3:8)
+reltols = 1.0 ./ 10.0 .^ (0:5)
+
+setups = [
+    Dict(:alg=>DP5())
+    Dict(:alg=>Tsit5())
+]
+names = ["DP5", "Tsit5"]
+wp = WorkPrecisionSet(prob,abstols,reltols,setups,names=names,save_everystep=false,numruns=100)
+
+plt = @test_nowarn plot(wp)
+@test plt[1][1][:x] ≈ wp[1].errors
+@test plt[1][2][:x] ≈ wp[2].errors
+@test plt[1][1][:label] == names[1]
+@test plt[1][2][:label] == names[2]
+@test_throws ArgumentError plot(wp, view=:dt_convergence)
+
+dts = 1.0./2.0.^((1:length(reltols)) .+ 1)
+setups = [
+    Dict(:alg=>Euler(),:dts=>dts)
+    Dict(:alg=>Heun(),:dts=>dts)
+    Dict(:alg=>DP5(),:dts=>dts,:adaptive=>false)
+    Dict(:alg=>Tsit5(),:dts=>dts,:adaptive=>false)
+    Dict(:alg=>Tsit5())
+]
+names = ["Euler", "Heun", "DP5 fixed step", "Tsit5 fixed step", "Tsit5 adaptive"]
+wp = WorkPrecisionSet(prob,abstols,reltols,setups,names=names,save_everystep=false,numruns=100)
+
+plt = @test_nowarn plot(wp)
+@test all(plt[1][i][:x] ≈ wp[i].errors for i in 1:5)
+@test all(plt[1][i][:label] == names[i] for i in 1:5)
+
+plt = @test_nowarn plot(wp, view=:dt_convergence, legend=:bottomright)
+@test all(plt[1][i][:x] == plt[1][i+4][:x] == dts == wp.setups[i][:dts] for i in 1:4)
+@test all(plt[1][i+4][:y] ≈ wp[i].errors for i in 1:4)
+@test all(startswith(plt[1][i+4][:label], names[i]) for i in 1:4)
+@test_throws BoundsError plt[1][9]

--- a/test/plotrecipes_tests.jl
+++ b/test/plotrecipes_tests.jl
@@ -6,19 +6,19 @@ Random.seed!(123)
 
 gr()
 
-# Linear ODE
-function flin(du, u, p, t)
+# Linear ODE system
+f_rode_lin = function (du, u, p, t)
     @inbounds for i in eachindex(u)
         du[i] = cos(t) * u[i]
     end
 end
 
-function flin_analytic(u₀, p, t)
+f_rode_lin_analytic = function (u₀, p, t)
     u₀ * exp(sin(t))
 end
 
 tspan = (0.0, 10.0)
-prob = ODEProblem(ODEFunction(flin, analytic = flin_analytic), rand(10, 10), tspan)
+prob = ODEProblem(ODEFunction(f_rode_lin, analytic = f_rode_lin_analytic), rand(10, 10), tspan)
 
 abstols = 1.0 ./ 10.0 .^ (3:8)
 reltols = 1.0 ./ 10.0 .^ (0:5)

--- a/test/plotrecipes_tests.jl
+++ b/test/plotrecipes_tests.jl
@@ -26,15 +26,16 @@ reltols = 1.0 ./ 10.0 .^ (0:5)
 
 setups = [Dict(:alg => DP5())
           Dict(:alg => Tsit5())]
-names = ["DP5", "Tsit5"]
-wp = WorkPrecisionSet(prob, abstols, reltols, setups, names = names, save_everystep = false,
+wp_names = ["DP5", "Tsit5"]
+wp = WorkPrecisionSet(prob, abstols, reltols, setups, names = wp_names,
+                      save_everystep = false,
                       numruns = 100)
 
 plt = @test_nowarn plot(wp)
 @test plt[1][1][:x] ≈ wp[1].errors
 @test plt[1][2][:x] ≈ wp[2].errors
-@test plt[1][1][:label] == names[1]
-@test plt[1][2][:label] == names[2]
+@test plt[1][1][:label] == wp_names[1]
+@test plt[1][2][:label] == wp_names[2]
 @test_nowarn plot(wp, color = [1 2])
 @test_nowarn plot(wp, color = :blue)
 @test_throws ArgumentError plot(wp, view = :dt_convergence)
@@ -44,18 +45,19 @@ setups = [Dict(:alg => Euler(), :dts => dts)
           Dict(:alg => Heun(), :dts => dts)
           Dict(:alg => Tsit5(), :dts => dts, :adaptive => false)
           Dict(:alg => Tsit5())]
-names = ["Euler", "Heun", "Tsit5 fixed step", "Tsit5 adaptive"]
-wp = WorkPrecisionSet(prob, abstols, reltols, setups, names = names, save_everystep = false,
+wp_names = ["Euler", "Heun", "Tsit5 fixed step", "Tsit5 adaptive"]
+wp = WorkPrecisionSet(prob, abstols, reltols, setups, names = wp_names,
+                      save_everystep = false,
                       numruns = 100)
 
 plt = @test_nowarn plot(wp)
 @test all(plt[1][i][:x] ≈ wp[i].errors for i in 1:4)
-@test all(plt[1][i][:label] == names[i] for i in 1:4)
+@test all(plt[1][i][:label] == wp_names[i] for i in 1:4)
 
 plt = @test_nowarn plot(wp, view = :dt_convergence, legend = :bottomright)
 @test all(plt[1][i][:x] == plt[1][i + 3][:x] == dts == wp.setups[i][:dts] for i in 1:3)
 @test all(plt[1][i + 3][:y] ≈ wp[i].errors for i in 1:3)
-@test all(startswith(plt[1][i + 3][:label], names[i]) for i in 1:3)
+@test all(startswith(plt[1][i + 3][:label], wp_names[i]) for i in 1:3)
 @test_throws BoundsError plt[1][7]
 @test_nowarn plot(wp, view = :dt_convergence, color = [:red :orange :green])
 @test_nowarn plot(wp, view = :dt_convergence, color = :lightblue, title = "Δt Convergence")

--- a/test/plotrecipes_tests.jl
+++ b/test/plotrecipes_tests.jl
@@ -17,47 +17,44 @@ function f2d_analytic(u₀, p, t)
     u₀ * exp(sin(t))
 end
 
-tspan = (0.0,10.0)
-prob = ODEProblem(ODEFunction(f2d,analytic=f2d_analytic),rand(10,10),tspan)
-
+tspan = (0.0, 10.0)
+prob = ODEProblem(ODEFunction(f2d, analytic = f2d_analytic), rand(10, 10), tspan)
 
 abstols = 1.0 ./ 10.0 .^ (3:8)
 reltols = 1.0 ./ 10.0 .^ (0:5)
 
-setups = [
-    Dict(:alg=>DP5())
-    Dict(:alg=>Tsit5())
-]
+setups = [Dict(:alg => DP5())
+          Dict(:alg => Tsit5())]
 names = ["DP5", "Tsit5"]
-wp = WorkPrecisionSet(prob,abstols,reltols,setups,names=names,save_everystep=false,numruns=100)
+wp = WorkPrecisionSet(prob, abstols, reltols, setups, names = names, save_everystep = false,
+                      numruns = 100)
 
 plt = @test_nowarn plot(wp)
 @test plt[1][1][:x] ≈ wp[1].errors
 @test plt[1][2][:x] ≈ wp[2].errors
 @test plt[1][1][:label] == names[1]
 @test plt[1][2][:label] == names[2]
-@test_nowarn plot(wp, color=[1 2])
-@test_nowarn plot(wp, color=:blue)
-@test_throws ArgumentError plot(wp, view=:dt_convergence)
+@test_nowarn plot(wp, color = [1 2])
+@test_nowarn plot(wp, color = :blue)
+@test_throws ArgumentError plot(wp, view = :dt_convergence)
 
-dts = 1.0./2.0.^((1:length(reltols)) .+ 1)
-setups = [
-    Dict(:alg=>Euler(),:dts=>dts)
-    Dict(:alg=>Heun(),:dts=>dts)
-    Dict(:alg=>Tsit5(),:dts=>dts,:adaptive=>false)
-    Dict(:alg=>Tsit5())
-]
+dts = 1.0 ./ 2.0 .^ ((1:length(reltols)) .+ 1)
+setups = [Dict(:alg => Euler(), :dts => dts)
+          Dict(:alg => Heun(), :dts => dts)
+          Dict(:alg => Tsit5(), :dts => dts, :adaptive => false)
+          Dict(:alg => Tsit5())]
 names = ["Euler", "Heun", "Tsit5 fixed step", "Tsit5 adaptive"]
-wp = WorkPrecisionSet(prob,abstols,reltols,setups,names=names,save_everystep=false,numruns=100)
+wp = WorkPrecisionSet(prob, abstols, reltols, setups, names = names, save_everystep = false,
+                      numruns = 100)
 
 plt = @test_nowarn plot(wp)
 @test all(plt[1][i][:x] ≈ wp[i].errors for i in 1:4)
 @test all(plt[1][i][:label] == names[i] for i in 1:4)
 
-plt = @test_nowarn plot(wp, view=:dt_convergence, legend=:bottomright)
-@test all(plt[1][i][:x] == plt[1][i+3][:x] == dts == wp.setups[i][:dts] for i in 1:3)
-@test all(plt[1][i+3][:y] ≈ wp[i].errors for i in 1:3)
-@test all(startswith(plt[1][i+3][:label], names[i]) for i in 1:3)
+plt = @test_nowarn plot(wp, view = :dt_convergence, legend = :bottomright)
+@test all(plt[1][i][:x] == plt[1][i + 3][:x] == dts == wp.setups[i][:dts] for i in 1:3)
+@test all(plt[1][i + 3][:y] ≈ wp[i].errors for i in 1:3)
+@test all(startswith(plt[1][i + 3][:label], names[i]) for i in 1:3)
 @test_throws BoundsError plt[1][7]
-@test_nowarn plot(wp, view=:dt_convergence, color=[:red :orange :green])
-@test_nowarn plot(wp, view=:dt_convergence, color=:lightblue, title="Δt Convergence")
+@test_nowarn plot(wp, view = :dt_convergence, color = [:red :orange :green])
+@test_nowarn plot(wp, view = :dt_convergence, color = :lightblue, title = "Δt Convergence")

--- a/test/plotrecipes_tests.jl
+++ b/test/plotrecipes_tests.jl
@@ -7,18 +7,18 @@ Random.seed!(123)
 gr()
 
 # Linear ODE
-function f(du, u, p, t)
+function flin(du, u, p, t)
     @inbounds for i in eachindex(u)
         du[i] = cos(t) * u[i]
     end
 end
 
-function f_analytic(u₀, p, t)
+function flin_analytic(u₀, p, t)
     u₀ * exp(sin(t))
 end
 
 tspan = (0.0, 10.0)
-prob = ODEProblem(ODEFunction(f, analytic = f_analytic), rand(10, 10), tspan)
+prob = ODEProblem(ODEFunction(flin, analytic = flin_analytic), rand(10, 10), tspan)
 
 abstols = 1.0 ./ 10.0 .^ (3:8)
 reltols = 1.0 ./ 10.0 .^ (0:5)

--- a/test/plotrecipes_tests.jl
+++ b/test/plotrecipes_tests.jl
@@ -6,19 +6,19 @@ Random.seed!(123)
 
 gr()
 
-# 2D Linear ODE
-function f2d(du, u, p, t)
+# Linear ODE
+function f(du, u, p, t)
     @inbounds for i in eachindex(u)
         du[i] = cos(t) * u[i]
     end
 end
 
-function f2d_analytic(u₀, p, t)
+function f_analytic(u₀, p, t)
     u₀ * exp(sin(t))
 end
 
 tspan = (0.0, 10.0)
-prob = ODEProblem(ODEFunction(f2d, analytic = f2d_analytic), rand(10, 10), tspan)
+prob = ODEProblem(ODEFunction(f, analytic = f_analytic), rand(10, 10), tspan)
 
 abstols = 1.0 ./ 10.0 .^ (3:8)
 reltols = 1.0 ./ 10.0 .^ (0:5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,3 +8,4 @@ using Test
 @time @testset "ODE Tableau Convergence Tests" begin include("ode_tableau_convergence_tests.jl") end ## Windows 32-bit fails on Butcher62 convergence test
 @time @testset "Analyticless Stochastic WP" begin include("analyticless_stochastic_wp.jl") end
 @time @testset "Stability Region Tests" begin include("stability_region_test.jl") end
+@time @testset "Plot Recipes" begin include("plotrecipes_tests.jl") end


### PR DESCRIPTION
This adds the keyword `view` to the plot recipe of a `WorkPrecisionSet` that computes and displays the order of convergence with respect to the time step, for fixed step methods.

If `wp` isa  `WorkPrecisionSet`, then `plot(wp)` works as before (it is understood as the default `view=:benchmark`), while `plot(wp, view=:dt_convergence)` plots the Δt convergence.

A new test file for testing the plot recipe was included. The tested ODE is a 2D linear `du/dt = cos(t) u`, and here are the results of `plot(wp)` and `plot(wp, view=:dt_convergence, legend=:bottomright)` with the following setup (notice I included an adaptive `Tsit5()` which is ignored in the Δt-convergence plot, but not in the usual benchmark plot):
```julia
setups = [
    Dict(:alg=>Euler(),:dts=>dts)
    Dict(:alg=>Heun(),:dts=>dts)
    Dict(:alg=>Tsit5(),:dts=>dts,:adaptive=>false)
    Dict(:alg=>Tsit5())
]
```

![plot_4](https://user-images.githubusercontent.com/17986148/188270953-b51c9236-75c4-4c93-b712-40471e31388b.png)

![plot_13](https://user-images.githubusercontent.com/17986148/188273664-d6d41a29-e2c5-44fb-91e6-70ae3cd37e08.png)

