### PR TITLE
Change marker to markershape

### DIFF
--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -33,7 +33,7 @@ end
     xguide --> "Error"
     xscale --> :log10
     yscale --> :log10
-    marker --> :auto
+    markershape --> :auto
     wp.errors, wp.times
 end
 
@@ -45,7 +45,7 @@ end
         xguide --> "Error"
         xscale --> :log10
         yscale --> :log10
-        marker --> :auto
+        markershape --> :auto
         errors = Vector{Any}(undef, 0)
         times = Vector{Any}(undef, 0)
         for i in 1:length(wp_set)
@@ -93,7 +93,7 @@ end
             xguide --> "Δt"
             xscale --> :log10
             yscale --> :log10
-            marker --> :auto
+            markershape --> :auto
             label --> reshape(names, 1, length(idts))
             return dts, errors
         end


### PR DESCRIPTION
Change the `marker` to `markershape` in WP diagram plot recipes. This should enable users to change the markershape in WP diagrams.