### PR TITLE
Work precision diagram for nonlinearproblem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -42,4 +42,4 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DelayDiffEq", "DDEProblemLibrary", "ODEProblemLibrary", "SDEProblemLibrary", "OrdinaryDiffEq", "ParameterizedFunctions", "Random", "StochasticDiffEq", "StochasticDelayDiffEq", "Plots", "Test"]
+test = ["DelayDiffEq", "DDEProblemLibrary", "NonlinearSolve", "ODEProblemLibrary", "SDEProblemLibrary", "OrdinaryDiffEq", "ParameterizedFunctions", "Random", "StochasticDiffEq", "StochasticDelayDiffEq", "Plots", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -30,6 +30,7 @@ julia = "1.6"
 [extras]
 DelayDiffEq = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 DDEProblemLibrary = "f42792ee-6ffc-4e2a-ae83-8ee2f22de800"
+NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 ParameterizedFunctions = "65888b18-ceab-5e60-b2b9-181511a3b968"

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -297,7 +297,7 @@ function WorkPrecision(prob::NonlinearProblem, alg, abstols, reltols, dts = noth
             sol = solve(_prob, alg; kwargs..., abstol = abstols[i], reltol = reltols[i])
 
             if error_estimate == :l2
-                errors[i] = sqrt(sum((sol .- appxsol) .^2))
+                errors[i] = sqrt(sum(ab2, sol .- appxsol))
             else
                 error("Unsupported norm used: $(error_estimate).")
             end

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -276,7 +276,6 @@ end
 # Work precision information for a nonlinear problem.
 function WorkPrecision(prob::NonlinearProblem, alg, abstols, reltols, dts = nothing; name = nothing, appxsol = nothing, error_estimate = :l2, numruns = 20, seconds = 2, kwargs...)
     isnothing(appxsol) && error("Must provide the real value as the \"appxsol\" kwarg.")
-    println("HERE")
 
     N = length(abstols)
     errors = Vector{Float64}(undef, N)

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -273,6 +273,57 @@ function WorkPrecision(prob, alg, abstols, reltols, dts = nothing;
     return WorkPrecision(prob, abstols, reltols, errors, times, name, N)
 end
 
+# Work precision information for a nonlinear problem.
+function WorkPrecision(prob::NonlinearProblem, alg, abstols, reltols, dts = nothing; name = nothing, appxsol = nothing, error_estimate = :l2, numruns = 20, seconds = 2, kwargs...)
+    isnothing(appxsol) && error("Must provide the real value as the \"appxsol\" kwarg.")
+    println("HERE")
+
+    N = length(abstols)
+    errors = Vector{Float64}(undef, N)
+    times = Vector{Float64}(undef, N)
+    if name === nothing
+        name = "WP-Alg"
+    end
+
+    if haskey(kwargs, :prob_choice)
+        _prob = prob[kwargs[:prob_choice]]
+    elseif prob isa AbstractArray
+        _prob = prob[1]
+    else
+        _prob = prob
+    end
+
+    let _prob = _prob
+        for i in 1:N
+            sol = solve(_prob, alg; kwargs..., abstol = abstols[i], reltol = reltols[i])
+
+            if error_estimate == :l2
+                errors[i] = sqrt(sum((sol .- appxsol) .^2))
+            else
+                error("Unsupported norm used: $(error_estimate).")
+            end
+
+            benchmark_f = let dts = dts, _prob = _prob, alg = alg, sol = sol,
+                abstols = abstols, reltols = reltols, kwargs = kwargs
+
+                () -> @elapsed solve(_prob, alg;
+                                            abstol = abstols[i],
+                                            reltol = reltols[i],
+                                            kwargs...)
+            end
+            benchmark_f() # pre-compile
+
+            b_t = benchmark_f()
+            if b_t > seconds
+                times[i] = b_t
+            else
+                times[i] = mapreduce(i -> benchmark_f(), min, 2:numruns; init = b_t)
+            end
+        end
+    end
+    return WorkPrecision(prob, abstols, reltols, errors, times, name, N)
+end
+
 function WorkPrecisionSet(prob,
                           abstols, reltols, setups;
                           print_names = false, names = nothing, appxsol = nothing,

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -297,7 +297,7 @@ function WorkPrecision(prob::NonlinearProblem, alg, abstols, reltols, dts = noth
             sol = solve(_prob, alg; kwargs..., abstol = abstols[i], reltol = reltols[i])
 
             if error_estimate == :l2
-                errors[i] = sqrt(sum(ab2, sol .- appxsol))
+                errors[i] = sqrt(sum(abs2, sol .- appxsol))
             else
                 error("Unsupported norm used: $(error_estimate).")
             end

--- a/test/nonlinearsolve_wpdiagram_tests.jl
+++ b/test/nonlinearsolve_wpdiagram_tests.jl
@@ -2,21 +2,23 @@
 using NonlinearSolve, DiffEqDevTools, Plots
 
 # Prepares NonlinearProblem.
-f(u, p) = u .* u .- p
-u0 = [1.0, 1.0]
-p = 2.0
-static_prob = NonlinearProblem(f, u0, p)
-real_sol = solve(static_prob, NewtonRaphson(), reltol = 1e-15, abstol = 1e-15)
+let
+    f(u, p) = u .* u .- p
+    u0 = [1.0, 1.0]
+    p = 2.0
+    static_prob = NonlinearProblem(f, u0, p)
+    real_sol = solve(static_prob, NewtonRaphson(), reltol = 1e-15, abstol = 1e-15)
 
-# Sets WP input.
-abstols = 1.0 ./ 10.0 .^ (8:12)
-reltols = 1.0 ./ 10.0 .^ (8:12)
-setups = [Dict(:alg=>NewtonRaphson())
-          Dict(:alg=>TrustRegion())]
-solnames = ["NewtonRaphson";"TrustRegion"]
+    # Sets WP input.
+    abstols = 1.0 ./ 10.0 .^ (8:12)
+    reltols = 1.0 ./ 10.0 .^ (8:12)
+    setups = [Dict(:alg=>NewtonRaphson())
+            Dict(:alg=>TrustRegion())]
+    solnames = ["NewtonRaphson";"TrustRegion"]
 
-# Makes WP-diagram
-wp = WorkPrecisionSet(static_prob, abstols, reltols, setups; names=solnames, numruns=100, appxsol=real_sol, error_estimate=:l2) 
+    # Makes WP-diagram
+    wp = WorkPrecisionSet(static_prob, abstols, reltols, setups; names=solnames, numruns=100, appxsol=real_sol, error_estimate=:l2) 
 
-# Checks that all errors are small (they definitely should be).
-all(vcat(getfield.(wp.wps, :errors)...) .< 10e-9)
+    # Checks that all errors are small (they definitely should be).
+    all(vcat(getfield.(wp.wps, :errors)...) .< 10e-9)
+end

--- a/test/nonlinearsolve_wpdiagram_tests.jl
+++ b/test/nonlinearsolve_wpdiagram_tests.jl
@@ -1,0 +1,22 @@
+# Fetch pakages.
+using NonlinearSolve, StaticArrays, DiffEqDevTools, Plots
+
+# Prepares NonlinearProblem.
+f(u, p) = u .* u .- p
+u0 = @SVector[1.0, 1.0]
+p = 2.0
+static_prob = NonlinearProblem(f, u0, p)
+real_sol = solve(static_prob, NewtonRaphson(), reltol = 1e-15, abstol = 1e-15)
+
+# Sets WP input.
+abstols = 1.0 ./ 10.0 .^ (8:12)
+reltols = 1.0 ./ 10.0 .^ (8:12)
+setups = [Dict(:alg=>NewtonRaphson())
+          Dict(:alg=>TrustRegion())]
+solnames = ["NewtonRaphson";"TrustRegion"]
+
+# Makes WP-diagram
+wp = WorkPrecisionSet(static_prob, abstols, reltols, setups; names=solnames, numruns=100, appxsol=real_sol, error_estimate=:l2) 
+
+# Checks that all errors are small (they definitely should be).
+all(vcat(getfield.(wp.wps, :errors)...) .< 10e-9)

--- a/test/nonlinearsolve_wpdiagram_tests.jl
+++ b/test/nonlinearsolve_wpdiagram_tests.jl
@@ -1,9 +1,9 @@
 # Fetch pakages.
-using NonlinearSolve, StaticArrays, DiffEqDevTools, Plots
+using NonlinearSolve, DiffEqDevTools, Plots
 
 # Prepares NonlinearProblem.
 f(u, p) = u .* u .- p
-u0 = @SVector[1.0, 1.0]
+u0 = [1.0, 1.0]
 p = 2.0
 static_prob = NonlinearProblem(f, u0, p)
 real_sol = solve(static_prob, NewtonRaphson(), reltol = 1e-15, abstol = 1e-15)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,3 +9,4 @@ using Test
 @time @testset "Analyticless Stochastic WP" begin include("analyticless_stochastic_wp.jl") end
 @time @testset "Stability Region Tests" begin include("stability_region_test.jl") end
 @time @testset "Plot Recipes" begin include("plotrecipes_tests.jl") end
+@time @testset "Plot Recipes (Nonlinearsolve WP-diagrams)" begin include("nonlinearsolve_wpdiagram_tests.jl") end


### PR DESCRIPTION
Enable WP-diagrams to be created from `NonlinearProblem`s.

Sample code:
```julia
# Fetch pakages.
using NonlinearSolve, StaticArrays, DiffEqDevTools, Plots

# Prepares NonlinearProblem.
f(u, p) = u .* u .- p
u0 = @SVector[1.0, 1.0]
p = 2.0
static_prob = NonlinearProblem(f, u0, p)
real_sol = solve(static_prob, NewtonRaphson(), reltol = 1e-15, abstol = 1e-15)

# Sets WP input.
abstols = 1.0 ./ 10.0 .^ (4:12)
reltols = 1.0 ./ 10.0 .^ (4:12)
setups = [Dict(:alg=>NewtonRaphson())
          Dict(:alg=>TrustRegion())]
solnames = ["NewtonRaphson";"TrustRegion"]

# Plots WP-diagram.
wp = WorkPrecisionSet(static_prob, abstols, reltols, setups; names=solnames, numruns=100, appxsol=real_sol, error_estimate=:l2) # Only l2 currently supported.
plot(wp)
``` 
The output here is trivial (since all cases solves the problem perfectly, giving all errors = `0.0`). However, if I give the wrong input real solution we can get something like:
![image](https://github.com/SciML/DiffEqDevTools.jl/assets/18099310/b33876b4-c4fe-4470-a6c9-ea7e13e98293)

