### PR TITLE
Add BVP precision diagram

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqDevTools"
 uuid = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.36.0"
+version = "2.37.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/Project.toml
+++ b/Project.toml
@@ -28,6 +28,8 @@ SciMLBase = "1.74"
 julia = "1.6"
 
 [extras]
+BoundaryValueDiffEq = "764a87c0-6b3e-53db-9096-fe964310641d"
+BVProblemLibrary = "ded0fc24-dfea-4565-b1d9-79c027d14d84"
 DelayDiffEq = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 DDEProblemLibrary = "f42792ee-6ffc-4e2a-ae83-8ee2f22de800"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
@@ -42,4 +44,4 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DelayDiffEq", "DDEProblemLibrary", "NonlinearSolve", "ODEProblemLibrary", "SDEProblemLibrary", "OrdinaryDiffEq", "ParameterizedFunctions", "Random", "StochasticDiffEq", "StochasticDelayDiffEq", "Plots", "Test"]
+test = ["BoundaryValueDiffEq", "BVProblemLibrary", "DelayDiffEq", "DDEProblemLibrary", "NonlinearSolve", "ODEProblemLibrary", "SDEProblemLibrary", "OrdinaryDiffEq", "ParameterizedFunctions", "Random", "StochasticDiffEq", "StochasticDelayDiffEq", "Plots", "Test"]

--- a/src/DiffEqDevTools.jl
+++ b/src/DiffEqDevTools.jl
@@ -11,7 +11,7 @@ import Base: length
 import DiffEqBase: AbstractODEProblem, AbstractDDEProblem, AbstractDDEAlgorithm,
                    AbstractODESolution, AbstractRODEProblem, AbstractSDEProblem,
                    AbstractSDDEProblem, AbstractEnsembleProblem,
-                   AbstractDAEProblem, @def, ConvergenceSetup, DEAlgorithm,
+                   AbstractDAEProblem, AbstractBVProblem, @def, ConvergenceSetup, DEAlgorithm,
                    ODERKTableau, AbstractTimeseriesSolution, ExplicitRKTableau,
                    ImplicitRKTableau
 

--- a/test/benchmark_tests.jl
+++ b/test/benchmark_tests.jl
@@ -1,6 +1,7 @@
-using OrdinaryDiffEq, DelayDiffEq, DiffEqDevTools, DiffEqBase, Test
+using OrdinaryDiffEq, DelayDiffEq, BoundaryValueDiffEq, DiffEqDevTools, DiffEqBase, Test
 using ODEProblemLibrary: prob_ode_2Dlinear, prob_ode_linear
 using DDEProblemLibrary: prob_dde_constant_1delay_ip
+using BVProblemLibrary: prob_bvp_linear_1
 
 ## Setup Tests
 
@@ -176,3 +177,23 @@ setups = [Dict(:alg => RadauIIA5()),
     Dict(:alg => RosShamp4())]
 shoot = Shootout(prob, setups; appxsol = TestSolution(sol))
 @test shoot.names == ["RadauIIA5", "RosShamp4"]
+
+# BVP problem
+prob = prob_bvp_linear_1
+abstols = 1.0 ./ 10.0 .^ (2:3)
+reltols = 1.0 ./ 10.0 .^ (2:3)
+sol = solve(prob, Shooting(Tsit5()), abstol = 1e-14, reltol = 1e-14)
+test_sol = TestSolution(sol.t, sol.u)
+
+setups = [Dict(:alg => MIRK4(), :dts => 1.0 ./ 5.0 .^ ((1:length(reltols)) .+ 1))
+    Dict(:alg => MIRK5(), :dts => 1.0 ./ 5.0 .^ ((1:length(reltols)) .+ 1))]
+println("Test MIRK4 and MIRK5")
+wp = WorkPrecisionSet(prob,
+    abstols,
+    reltols,
+    setups;
+    approxsol = sol,
+    names = labels,
+    print_names = true)
+@test wp.names == ["MIRK4", "MIRK5"]
+println("BVP Done")

--- a/test/benchmark_tests.jl
+++ b/test/benchmark_tests.jl
@@ -187,6 +187,8 @@ test_sol = TestSolution(sol.t, sol.u)
 
 setups = [Dict(:alg => MIRK4(), :dts => 1.0 ./ 5.0 .^ ((1:length(reltols)) .+ 1))
     Dict(:alg => MIRK5(), :dts => 1.0 ./ 5.0 .^ ((1:length(reltols)) .+ 1))]
+labels = ["MIRK4", "MIRK5"]
+
 println("Test MIRK4 and MIRK5")
 wp = WorkPrecisionSet(prob,
     abstols,


### PR DESCRIPTION
```julia
using BoundaryValueDiffEq, DiffEqDevTools, OrdinaryDiffEq

λ = 1
function prob_bvp_linear_1_analytic(u, λ, t)
    a = 1 / sqrt(λ)
    [(exp(-a * t) - exp((t - 2) * a)) / (1 - exp(-2 * a)),
        (-a * exp(-t * a) - a * exp((t - 2) * a)) / (1 - exp(-2 * a))]
end
function prob_bvp_linear_1_f!(du, u, p, t)
    du[1] = u[2]
    du[2] = 1 / p * u[1]
end
function prob_bvp_linear_1_bc!(res, u, p, t)
    res[1] = u[1][1] - 1
    res[2] = u[end][1]
end
prob_bvp_linear_1_function = ODEFunction(prob_bvp_linear_1_f!,
    analytic = prob_bvp_linear_1_analytic)
prob_bvp_linear_1_tspan = (0.0, 1.0)
prob_bvp_linear_1 = BVProblem(prob_bvp_linear_1_function,
    prob_bvp_linear_1_bc!,
    [1.0, 0.0],
    prob_bvp_linear_1_tspan,
    λ)
sol=solve(prob_bvp_linear_1, Shooting(Tsit5()), abstol=1e-14, reltol=1e-14)
test_sol = TestSolution(sol.t, sol.u)

abstols = 1.0 ./ 10.0 .^ (2:5)
reltols = 1.0 ./ 10.0 .^ (2:5);
setups = [Dict(:alg=>MIRK4(), :dts=>1.0./5.0.^((1:length(reltols)) .+ 1))
Dict(:alg=>MIRK5(), :dts=>1.0./5.0.^((1:length(reltols)) .+ 1))]
labels = ["Julia: MIRK4"
"Julia: MIRK5"]

wp=WorkPrecisionSet(prob_bvp_linear_1,abstols,reltols,setups; appxsol = test_sol, names = labels,print_names = true)
```

![bvp_wp](https://github.com/SciML/DiffEqDevTools.jl/assets/52615090/1fbbf661-fccf-40a3-8cbd-0a8b3f3bebc6)
