### PR TITLE
Add the name of the error estimate to the plotting recipe

### DIFF
--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -42,7 +42,7 @@ end
         seriestype --> :path
         linewidth --> 3
         yguide --> "Time (s)"
-        xguide --> "Error"
+        xguide --> "Error ($(wp_set.error_estimate))"
         xscale --> :log10
         yscale --> :log10
         markershape --> :auto


### PR DESCRIPTION
I think the work-precision diagrams would get easier to read if the xlabel does not say "Error", but "Error (L2)" / "Error (final)" / etc. What do you think? This PR would implement this change.