### PR TITLE
Save all errors in `WorkPrecision`, not just the `error_estimate`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 RootedTrees = "47965b36-3f3e-11e9-0dcf-4570dfd42a8c"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 
 [compat]
 BVProblemLibrary = "0.1"

--- a/src/DiffEqDevTools.jl
+++ b/src/DiffEqDevTools.jl
@@ -1,6 +1,6 @@
 module DiffEqDevTools
 
-using DiffEqBase, RecipesBase, RecursiveArrayTools, DiffEqNoiseProcess
+using DiffEqBase, RecipesBase, RecursiveArrayTools, DiffEqNoiseProcess, StructArrays
 
 using LinearAlgebra, Distributed
 

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -443,7 +443,7 @@ function WorkPrecision(prob::NonlinearProblem, alg, abstols, reltols, dts = noth
             end
         end
     end
-    return WorkPrecision(prob, abstols, reltols, errors, times, dts, stats, name, N)
+    return WorkPrecision(prob, abstols, reltols, errors, times, dts, stats, name, error_estimate, N)
 end
 
 function WorkPrecisionSet(prob,

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -290,7 +290,7 @@ function WorkPrecision(prob::AbstractBVProblem, alg, abstols, reltols, dts = not
     name = nothing, appxsol = nothing, error_estimate = :final,
     numruns = 20, seconds = 2, kwargs...)
     N = length(abstols)
-    errors = Vector{Float64}(undef, N)
+    errors = Vector{Dict{Symbol,Float64}}(undef, N)
     times = Vector{Float64}(undef, N)
     stats = Vector{Any}(undef, N)
     if name === nothing

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -596,7 +596,9 @@ function WorkPrecisionSet(prob::AbstractRODEProblem, abstols, reltols, setups,
     end
 
     stats = nothing
-    wps = [WorkPrecision(prob, _abstols[i], _reltols[i], errors[i], times[:, i], _dts[i], stats, names[i], error_estimate, N)
+    wps = [WorkPrecision(prob, _abstols[i], _reltols[i],
+                         StructArray(NamedTuple.(errors[i])),
+                         times[:, i], _dts[i], stats, names[i], error_estimate, N)
            for i in 1:N]
     WorkPrecisionSet(wps, N, abstols, reltols, prob, setups, names, error_estimate,
                      numruns_error)

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -595,7 +595,7 @@ function WorkPrecisionSet(prob::AbstractRODEProblem, abstols, reltols, setups,
     end
 
     stats = nothing
-    wps = [WorkPrecision(prob, _abstols[i], _reltols[i], errors[i], times[:, i], _dts[i], stats, names[i], N)
+    wps = [WorkPrecision(prob, _abstols[i], _reltols[i], errors[i], times[:, i], _dts[i], stats, names[i], error_estimate, N)
            for i in 1:N]
     WorkPrecisionSet(wps, N, abstols, reltols, prob, setups, names, error_estimate,
                      numruns_error)
@@ -702,7 +702,7 @@ function WorkPrecisionSet(prob::AbstractEnsembleProblem, abstols, reltols, setup
         end
     end
     stats = nothing
-    wps = [WorkPrecision(prob, _abstols[i], _reltols[i], errors[i], times[:, i], _dts[i], stats, names[i], N)
+    wps = [WorkPrecision(prob, _abstols[i], _reltols[i], errors[i], times[:, i], _dts[i], stats, names[i], error_estimate, N)
            for i in 1:N]
     WorkPrecisionSet(wps, N, abstols, reltols, prob, setups, names, error_estimate,
                      Int(trajectories))

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -394,7 +394,7 @@ end
 # Work precision information for a nonlinear problem.
 function WorkPrecision(prob::NonlinearProblem, alg, abstols, reltols, dts = nothing; name = nothing, appxsol = nothing, error_estimate = :l2, numruns = 20, seconds = 2, kwargs...)
     N = length(abstols)
-    errors = Vector{Float64}(undef, N)
+    errors = Vector{Dict{Symbol,Float64}}(undef, N)
     times = Vector{Float64}(undef, N)
     stats = Vector{Any}(undef, N)
     if name === nothing
@@ -417,9 +417,9 @@ function WorkPrecision(prob::NonlinearProblem, alg, abstols, reltols, dts = noth
 
             if error_estimate == :l2
                 if isnothing(appxsol)
-                    errors[i] = sqrt(sum(abs2, sol.resid))
+                    errors[i] = Dict(error_estimate => sqrt(sum(abs2, sol.resid)))
                 else
-                    errors[i] = sqrt(sum(abs2, sol .- appxsol))
+                    errors[i] = Dict(error_estimate => sqrt(sum(abs2, sol .- appxsol)))
                 end
             else
                 error("Unsupported norm used: $(error_estimate).")
@@ -443,7 +443,8 @@ function WorkPrecision(prob::NonlinearProblem, alg, abstols, reltols, dts = noth
             end
         end
     end
-    return WorkPrecision(prob, abstols, reltols, errors, times, dts, stats, name, error_estimate, N)
+
+    return WorkPrecision(prob, abstols, reltols, StructArray(NamedTuple.(errors)), times, dts, stats, name, error_estimate, N)
 end
 
 function WorkPrecisionSet(prob,

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -332,9 +332,15 @@ function WorkPrecision(prob::AbstractBVProblem, alg, abstols, reltols, dts = not
 
             if cur_appxsol !== nothing
                 errsol = appxtrue(sol, cur_appxsol)
-                errors[i] = mean(errsol.errors[error_estimate])
+                errors[i] = Dict{Symbol,Float64}()
+                for err in keys(errsol.errors)
+                    errors[i][err] = mean(errsol.errors[err])
+                end
             else
-                errors[i] = mean(sol.errors[error_estimate])
+                errors[i] = Dict{Symbol,Float64}()
+                for err in keys(errsol.errors)
+                    errors[i][err] = mean(errsol.errors[err])
+                end
             end
 
             benchmark_f = let dts = dts, _prob = _prob, alg = alg, sol = sol,
@@ -382,7 +388,7 @@ function WorkPrecision(prob::AbstractBVProblem, alg, abstols, reltols, dts = not
             end
         end
     end
-    return WorkPrecision(prob, abstols, reltols, errors, times, dts, stats, name, N)
+    return WorkPrecision(prob, abstols, reltols, StructArray(NamedTuple.(errors)), times, dts, stats, name, error_estimate, N)
 end
 
 # Work precision information for a nonlinear problem.

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -30,11 +30,12 @@ end
     label --> wp.name
     linewidth --> 3
     yguide --> "Time (s)"
-    xguide --> "Error"
+    xguide --> "Error ($(wp.error_estimate))"
     xscale --> :log10
     yscale --> :log10
     markershape --> :auto
-    wp.errors, wp.times
+    errors = getproperty(wp.errors, wp.error_estimate)
+    return errors, wp.times
 end
 
 @recipe function f(wp_set::WorkPrecisionSet; view = :benchmark, color = nothing)
@@ -49,7 +50,7 @@ end
         errors = Vector{Any}(undef, 0)
         times = Vector{Any}(undef, 0)
         for i in 1:length(wp_set)
-            push!(errors, wp_set[i].errors)
+            push!(errors, getproperty(wp_set[i].errors, wp_set.error_estimate))
             push!(times, wp_set[i].times)
         end
         label --> reshape(wp_set.names, 1, length(wp_set))
@@ -64,7 +65,7 @@ end
         convs = Vector{Any}(undef, 0)
         for i in idts
             push!(dts, wp_set.setups[i][:dts])
-            push!(errors, wp_set[i].errors)
+            push!(errors, getproperty(wp_set[i].errors, wp_set.error_estimate))
             lc, p = [one.(dts[end]) log.(dts[end])] \ log.(errors[end])
             push!(ps, p)
             push!(convs, exp(lc) * dts[end] .^ p)

--- a/test/analyticless_stochastic_wp.jl
+++ b/test/analyticless_stochastic_wp.jl
@@ -1,3 +1,4 @@
+using Random
 using StochasticDiffEq, DiffEqDevTools, Test
 using SDEProblemLibrary: prob_sde_additivesystem
 

--- a/test/benchmark_tests.jl
+++ b/test/benchmark_tests.jl
@@ -96,7 +96,7 @@ end
         wp_set[end]
         #println(wp_set)
         #show(wp_set)
-        @test (minimum(diff(wp_set[2].errors) .== 0)) # The errors for a fixed timestep method should be constant
+        @test (minimum(diff(wp_set[2].errors.final) .== 0)) # The errors for a fixed timestep method should be constant
         @test wp_set.names == ["RK4", "Euler", "BS3", "Midpoint", "BS5", "DP5"]
     end
 

--- a/test/benchmark_tests.jl
+++ b/test/benchmark_tests.jl
@@ -2,6 +2,7 @@ using OrdinaryDiffEq, DelayDiffEq, BoundaryValueDiffEq, DiffEqDevTools, DiffEqBa
 using ODEProblemLibrary: prob_ode_2Dlinear, prob_ode_linear
 using DDEProblemLibrary: prob_dde_constant_1delay_ip
 using BVProblemLibrary: prob_bvp_linear_1
+using Test
 
 ## Setup Tests
 
@@ -27,175 +28,197 @@ t2 = @elapsed sol2 = solve(prob, setups[1][:alg], dt = 1 / 2^(4))
 @test (sol2[end] == sol[end])
 
 ## Shootout Tests
+@testset "Shootout Tests" begin
+    println("Shootout Tests")
 
-println("Shootout Tests")
+    shoot = Shootout(prob, setups, dt = 1 / 2^(4))
 
-shoot = Shootout(prob, setups, dt = 1 / 2^(4))
+    #show(shoot)
+    #println(shoot)
+    shoot[end]
+    @test shoot.names == ["RK4", "Euler", "BS3", "Midpoint", "BS5", "DP5"]
 
-#show(shoot)
-#println(shoot)
-shoot[end]
-@test shoot.names == ["RK4", "Euler", "BS3", "Midpoint", "BS5", "DP5"]
+    set = ShootoutSet(probs, setups; dt = 1 / 2^(4))
 
-set = ShootoutSet(probs, setups; dt = 1 / 2^(4))
+    #println(set[1])
+    #println(set[:])
+    set[end]
+    set[1][:]
+    @test all(x -> x.names == ["RK4", "Euler", "BS3", "Midpoint", "BS5", "DP5"], set.shootouts)
 
-#println(set[1])
-#println(set[:])
-set[end]
-set[1][:]
-@test all(x -> x.names == ["RK4", "Euler", "BS3", "Midpoint", "BS5", "DP5"], set.shootouts)
+    @testset "RadauIIA5 and RosShamp4" begin
+        __f(u, p, t) = 1.01 * u
+        u0 = 1 / 2
+        tspan = (0.0, 1.0)
+        prob = ODEProblem(__f, u0, tspan)
+        sol = solve(prob, Rodas4(), reltol = 1e-8, abstol = 1e-8)
+        setups = [Dict(:alg => RadauIIA5()),
+                  Dict(:alg => RosShamp4())]
+        shoot = Shootout(prob, setups; appxsol = TestSolution(sol))
+        @test shoot.names == ["RadauIIA5", "RosShamp4"]
+    end
+end
 
 ## WorkPrecision Tests
-println("WorkPrecision Tests")
-println("Test DP5")
-wp = WorkPrecision(prob, DP5(), abstols, reltols; name = "Dormand-Prince 4/5")
+@testset "WorkPrecision Tests" begin
+    println("WorkPrecision Tests")
+    prob = prob_ode_linear
+    @testset "Test DP5 and Tsit5" begin
+        println("Test DP5")
+        wp = WorkPrecision(prob, DP5(), abstols, reltols; name = "Dormand-Prince 4/5")
 
-wp[1]
-wp[:]
-wp[end]
-#show(wp)
+        wp[1]
+        wp[:]
+        wp[end]
+        #show(wp)
+    end
 
-wp_set = WorkPrecisionSet(prob, abstols, reltols, setups; dt = 1 / 2^4, numruns = 2)
+    @testset "Test setups" begin
+        wp_set = WorkPrecisionSet(prob, abstols, reltols, setups; dt = 1 / 2^4, numruns = 2)
 
-wp_set[1]
-wp_set[:]
-wp_set[end]
-#println(wp_set)
-#show(wp_set)
-@test (minimum(diff(wp_set[2].errors) .== 0)) # The errors for a fixed timestep method should be constant
-@test wp_set.names == ["RK4", "Euler", "BS3", "Midpoint", "BS5", "DP5"]
+        wp_set[1]
+        wp_set[:]
+        wp_set[end]
+        #println(wp_set)
+        #show(wp_set)
+        @test (minimum(diff(wp_set[2].errors) .== 0)) # The errors for a fixed timestep method should be constant
+        @test wp_set.names == ["RK4", "Euler", "BS3", "Midpoint", "BS5", "DP5"]
+    end
 
-prob = prob_ode_2Dlinear
+    @testset "Test DP5 and Tsit5" begin
+        prob = prob_ode_2Dlinear
 
-abstols = 1 ./ 10 .^ (3:7)
-reltols = 1 ./ 10 .^ (0:4)
+        abstols = 1 ./ 10 .^ (3:7)
+        reltols = 1 ./ 10 .^ (0:4)
 
-setups = [Dict(:alg => DP5())
-          Dict(:alg => Tsit5(),
-               :abstols => 1 ./ 10 .^ (4:7),
-               :reltols => 1 ./ 10 .^ (1:4))]
+        setups = [Dict(:alg => DP5())
+                  Dict(:alg => Tsit5(),
+                       :abstols => 1 ./ 10 .^ (4:7),
+                       :reltols => 1 ./ 10 .^ (1:4))]
 
-sol = solve(prob, Vern7(), abstol = 1 / 10^14, reltol = 1 / 10^14)
-test_sol1 = TestSolution(sol)
-println("Test DP5 and Tsit5")
-wp = WorkPrecisionSet(prob, abstols, reltols, setups; save_everystep = false)
+        sol = solve(prob, Vern7(), abstol = 1 / 10^14, reltol = 1 / 10^14)
+        test_sol1 = TestSolution(sol)
 
-@test wp.names == ["DP5", "Tsit5"]
-@test length(wp[1]) == 5
-@test length(wp[2]) == 4
+        println("Test DP5 and Tsit5")
+        wp = WorkPrecisionSet(prob, abstols, reltols, setups; save_everystep = false)
 
-function lotka(du, u, p, t)
-    du[1] = 1.5 * u[1] - u[1] * u[2]
-    du[2] = -3 * u[2] + u[1] * u[2]
+        @test wp.names == ["DP5", "Tsit5"]
+        @test length(wp[1]) == 5
+        @test length(wp[2]) == 4
+    end
+
+    @testset "Test DP5, Tsit5, and Vern6" begin
+        function lotka(du, u, p, t)
+            du[1] = 1.5 * u[1] - u[1] * u[2]
+            du[2] = -3 * u[2] + u[1] * u[2]
+        end
+
+        prob = ODEProblem(lotka, [1.0; 1.0], (0.0, 10.0))
+
+        abstols = 1 ./ 10 .^ (6:9)
+        reltols = 1 ./ 10 .^ (3:6)
+        sol = solve(prob, Vern7(), abstol = 1 / 10^14, reltol = 1 / 10^14)
+        test_sol = TestSolution(sol)
+
+        setups = [Dict(:alg => DP5())
+                  Dict(:alg => Tsit5())
+                  Dict(:alg => Vern6())]
+        println("Test DP5, Tsit5, and Vern6")
+        wp = WorkPrecisionSet(prob, abstols, reltols, setups; appxsol = test_sol,
+                              save_everystep = false, numruns = 20, maxiters = 10000)
+        @test wp.names == ["DP5", "Tsit5", "Vern6"]
+    end
+
+    # Dual Problem
+    @testset "Dual Problem" begin
+        probs = [prob, prob_ode_2Dlinear]
+        setups = [Dict(:alg => DP5())
+                  Dict(:alg => Tsit5(), :prob_choice => 2)
+                  Dict(:alg => Vern6(), :prob_choice => 2)]
+        println("Test DP5, Tsit5, and Vern6")
+        wp = WorkPrecisionSet(probs, abstols, reltols, setups; appxsol = [test_sol, nothing],
+                              save_everystep = false, numruns = 20, maxiters = 10000)
+        @test wp.names == ["DP5", "Tsit5", "Vern6"]
+        wp = WorkPrecisionSet(probs, abstols, reltols, setups; appxsol = [test_sol, test_sol1],
+                              save_everystep = false, numruns = 20, maxiters = 10000)
+        @test wp.names == ["DP5", "Tsit5", "Vern6"]
+    end
+
+    # Dual DAE Problems
+    @testset "Dual DAE Problems" begin
+        function rober(du, u, p, t)
+            y₁, y₂, y₃ = u
+            k₁, k₂, k₃ = p
+            du[1] = -k₁ * y₁ + k₃ * y₂ * y₃
+            du[2] = k₁ * y₁ - k₂ * y₂^2 - k₃ * y₂ * y₃
+            du[3] = k₂ * y₂^2
+            nothing
+        end
+        prob1 = ODEProblem(rober, [1.0, 0.0, 0.0], (0.0, 1e5), [0.04, 3e7, 1e4])
+
+        ode_ref_sol = solve(prob1, Rodas5(), abstol = 1 / 10^14, reltol = 1 / 10^14);
+
+        function dae_rober(out, du, u, p, t)
+            out[1] = -0.04u[1] + 1e4 * u[2] * u[3] - du[1]
+            out[2] = +0.04u[1] - 3e7 * u[2]^2 - 1e4 * u[2] * u[3] - du[2]
+            out[3] = u[1] + u[2] + u[3] - 1.0
+        end
+        u₀ = [1.0, 0, 0]
+        du₀ = [-0.04, 0.04, 0.0]
+        tspan = (0.0, 100000.0)
+
+        differential_vars = [true, true, false]
+        prob2 = DAEProblem(dae_rober, du₀, u₀, tspan, differential_vars = differential_vars)
+
+        dae_ref_sol = solve(prob2, DFBDF(), abstol = 1 / 10^14, reltol = 1 / 10^14);
+
+        probs = [prob1, prob2]
+        setups = [Dict(:alg => Rodas5())
+                  Dict(:alg => DFBDF(), :prob_choice => 2)]
+        wp = WorkPrecisionSet(probs, abstols, reltols, setups; appxsol = [ode_ref_sol, dae_ref_sol],
+                              save_everystep = false, numruns = 20, maxiters = 10000)
+        @test wp.names == ["Rodas5", "DFBDF"]
+    end
+
+    # DDE problem
+    @testset "DDE problem" begin
+        prob = prob_dde_constant_1delay_ip
+
+        abstols = 1 ./ 10 .^ (7:10)
+        reltols = 1 ./ 10 .^ (4:7)
+        sol = solve(prob, MethodOfSteps(Vern9(), fpsolve = NLFunctional(; max_iter = 1000));
+                    reltol = 1e-8, abstol = 1e-8)
+        test_sol = TestSolution(sol)
+
+        setups = [Dict(:alg => MethodOfSteps(BS3()))
+                  Dict(:alg => MethodOfSteps(Tsit5()))]
+        println("Test MethodOfSteps BS3 and Tsit5")
+        wp = WorkPrecisionSet(prob, abstols, reltols, setups; appxsol = test_sol)
+        @test wp.names == ["BS3", "Tsit5"]
+        println("DDE Done")
+    end
+
+    # BVP problem
+    @testset "BVP Problem" begin
+        prob = prob_bvp_linear_1
+        abstols = 1.0 ./ 10.0 .^ (2:3)
+        reltols = 1.0 ./ 10.0 .^ (2:3)
+        sol = solve(prob, Shooting(Tsit5()), abstol = 1e-14, reltol = 1e-14)
+        test_sol = TestSolution(sol.t, sol.u)
+
+        setups = [Dict(:alg => MIRK4(), :dts => 1.0 ./ 5.0 .^ ((1:length(reltols)) .+ 1))
+                  Dict(:alg => MIRK5(), :dts => 1.0 ./ 5.0 .^ ((1:length(reltols)) .+ 1))]
+        labels = ["MIRK4", "MIRK5"]
+
+        println("Test MIRK4 and MIRK5")
+        wp = WorkPrecisionSet(prob,
+                              abstols,
+                              reltols,
+                              setups;
+                              appxsol = test_sol,
+                              names = labels,
+                              print_names = true)
+        @test wp.names == ["MIRK4", "MIRK5"]
+        println("BVP Done")
+    end
 end
-
-prob = ODEProblem(lotka, [1.0; 1.0], (0.0, 10.0))
-
-abstols = 1 ./ 10 .^ (6:9)
-reltols = 1 ./ 10 .^ (3:6)
-sol = solve(prob, Vern7(), abstol = 1 / 10^14, reltol = 1 / 10^14)
-test_sol = TestSolution(sol)
-
-setups = [Dict(:alg => DP5())
-          Dict(:alg => Tsit5())
-          Dict(:alg => Vern6())]
-println("Test DP5, Tsit5, and Vern6")
-wp = WorkPrecisionSet(prob, abstols, reltols, setups; appxsol = test_sol,
-                      save_everystep = false, numruns = 20, maxiters = 10000)
-@test wp.names == ["DP5", "Tsit5", "Vern6"]
-
-# Dual Problem
-
-probs = [prob, prob_ode_2Dlinear]
-setups = [Dict(:alg => DP5())
-          Dict(:alg => Tsit5(), :prob_choice => 2)
-          Dict(:alg => Vern6(), :prob_choice => 2)]
-println("Test DP5, Tsit5, and Vern6")
-wp = WorkPrecisionSet(probs, abstols, reltols, setups; appxsol = [test_sol, nothing],
-                      save_everystep = false, numruns = 20, maxiters = 10000)
-@test wp.names == ["DP5", "Tsit5", "Vern6"]
-wp = WorkPrecisionSet(probs, abstols, reltols, setups; appxsol = [test_sol, test_sol1],
-                      save_everystep = false, numruns = 20, maxiters = 10000)
-@test wp.names == ["DP5", "Tsit5", "Vern6"]
-
-# Dual DAE Problems
-function rober(du, u, p, t)
-    y₁, y₂, y₃ = u
-    k₁, k₂, k₃ = p
-    du[1] = -k₁ * y₁ + k₃ * y₂ * y₃
-    du[2] = k₁ * y₁ - k₂ * y₂^2 - k₃ * y₂ * y₃
-    du[3] = k₂ * y₂^2
-    nothing
-end
-prob1 = ODEProblem(rober, [1.0, 0.0, 0.0], (0.0, 1e5), [0.04, 3e7, 1e4])
-
-ode_ref_sol = solve(prob1, Rodas5(), abstol = 1 / 10^14, reltol = 1 / 10^14);
-
-function dae_rober(out, du, u, p, t)
-    out[1] = -0.04u[1] + 1e4 * u[2] * u[3] - du[1]
-    out[2] = +0.04u[1] - 3e7 * u[2]^2 - 1e4 * u[2] * u[3] - du[2]
-    out[3] = u[1] + u[2] + u[3] - 1.0
-end
-u₀ = [1.0, 0, 0]
-du₀ = [-0.04, 0.04, 0.0]
-tspan = (0.0, 100000.0)
-
-differential_vars = [true, true, false]
-prob2 = DAEProblem(dae_rober, du₀, u₀, tspan, differential_vars = differential_vars)
-
-dae_ref_sol = solve(prob2, DFBDF(), abstol = 1 / 10^14, reltol = 1 / 10^14);
-
-probs = [prob1, prob2]
-setups = [Dict(:alg => Rodas5())
-          Dict(:alg => DFBDF(), :prob_choice => 2)]
-wp = WorkPrecisionSet(probs, abstols, reltols, setups; appxsol = [ode_ref_sol, dae_ref_sol],
-                      save_everystep = false, numruns = 20, maxiters = 10000)
-@test wp.names == ["Rodas5", "DFBDF"]
-
-# DDE problem
-prob = prob_dde_constant_1delay_ip
-
-abstols = 1 ./ 10 .^ (7:10)
-reltols = 1 ./ 10 .^ (4:7)
-sol = solve(prob, MethodOfSteps(Vern9(), fpsolve = NLFunctional(; max_iter = 1000));
-            reltol = 1e-8, abstol = 1e-8)
-test_sol = TestSolution(sol)
-
-setups = [Dict(:alg => MethodOfSteps(BS3()))
-          Dict(:alg => MethodOfSteps(Tsit5()))]
-println("Test MethodOfSteps BS3 and Tsit5")
-wp = WorkPrecisionSet(prob, abstols, reltols, setups; appxsol = test_sol)
-@test wp.names == ["BS3", "Tsit5"]
-println("DDE Done")
-
-__f(u, p, t) = 1.01 * u
-u0 = 1 / 2
-tspan = (0.0, 1.0)
-prob = ODEProblem(__f, u0, tspan)
-sol = solve(prob, Rodas4(), reltol = 1e-8, abstol = 1e-8)
-setups = [Dict(:alg => RadauIIA5()),
-    Dict(:alg => RosShamp4())]
-shoot = Shootout(prob, setups; appxsol = TestSolution(sol))
-@test shoot.names == ["RadauIIA5", "RosShamp4"]
-
-# BVP problem
-prob = prob_bvp_linear_1
-abstols = 1.0 ./ 10.0 .^ (2:3)
-reltols = 1.0 ./ 10.0 .^ (2:3)
-sol = solve(prob, Shooting(Tsit5()), abstol = 1e-14, reltol = 1e-14)
-test_sol = TestSolution(sol.t, sol.u)
-
-setups = [Dict(:alg => MIRK4(), :dts => 1.0 ./ 5.0 .^ ((1:length(reltols)) .+ 1))
-    Dict(:alg => MIRK5(), :dts => 1.0 ./ 5.0 .^ ((1:length(reltols)) .+ 1))]
-labels = ["MIRK4", "MIRK5"]
-
-println("Test MIRK4 and MIRK5")
-wp = WorkPrecisionSet(prob,
-    abstols,
-    reltols,
-    setups;
-    appxsol = test_sol,
-    names = labels,
-    print_names = true)
-@test wp.names == ["MIRK4", "MIRK5"]
-println("BVP Done")

--- a/test/nonlinearsolve_wpdiagram_tests.jl
+++ b/test/nonlinearsolve_wpdiagram_tests.jl
@@ -17,14 +17,16 @@ let
     solnames = ["NewtonRaphson"; "TrustRegion"]
 
     # Makes WP-diagram
-    wp = WorkPrecisionSet(static_prob, abstols, reltols, setups; names=solnames, numruns=100, appxsol=real_sol, error_estimate=:l2) 
+    wp = WorkPrecisionSet(static_prob, abstols, reltols, setups; names=solnames, numruns=100, appxsol=real_sol, error_estimate=:l2)
 
     # Checks that all errors are small (they definitely should be).
-    @test all(vcat(getfield.(wp.wps, :errors)...) .< 10e-9)
-    @test length(plot(wp).series_list) == 2
+    @test all(vcat(getproperty.(getfield.(wp.wps, :errors), wp.error_estimate)...) .< 10e-9)
+    plt = @test_nowarn plot(wp)
+    @test length(plt.series_list) == 2
 
     # Check without appxsol.
-    wp = WorkPrecisionSet(static_prob, abstols, reltols, setups; names=solnames, numruns=100, error_estimate=:l2) 
-    @test all(vcat(getfield.(wp.wps, :errors)...) .< 10e-9)
-    @test length(plot(wp).series_list) == 2
+    wp = WorkPrecisionSet(static_prob, abstols, reltols, setups; names=solnames, numruns=100, error_estimate=:l2)
+    @test all(vcat(getproperty.(getfield.(wp.wps, :errors), wp.error_estimate)...) .< 10e-9)
+    plt = @test_nowarn plot(wp)
+    @test length(plt.series_list) == 2
 end

--- a/test/plotrecipes_tests.jl
+++ b/test/plotrecipes_tests.jl
@@ -1,63 +1,96 @@
 using Test
-using OrdinaryDiffEq, DiffEqDevTools, Plots
+using OrdinaryDiffEq, StochasticDiffEq, DiffEqDevTools, Plots
+import SDEProblemLibrary: prob_sde_additivesystem
 
 using Random
 Random.seed!(123)
 
 gr()
 
-# Linear ODE system
-f_rode_lin = function (du, u, p, t)
-    @inbounds for i in eachindex(u)
-        du[i] = cos(t) * u[i]
+@testset "ODE WorkPrecisionSet" begin
+    # Linear ODE system
+    f_rode_lin = function (du, u, p, t)
+        @inbounds for i in eachindex(u)
+            du[i] = cos(t) * u[i]
+        end
+    end
+
+    f_rode_lin_analytic = function (u₀, p, t)
+        u₀ * exp(sin(t))
+    end
+
+    tspan = (0.0, 10.0)
+    prob = ODEProblem(ODEFunction(f_rode_lin, analytic = f_rode_lin_analytic), rand(10, 10),
+                      tspan)
+
+    abstols = 1.0 ./ 10.0 .^ (3:8)
+    reltols = 1.0 ./ 10.0 .^ (0:5)
+
+    setups = [Dict(:alg => DP5())
+              Dict(:alg => Tsit5())]
+    wp_names = ["DP5", "Tsit5"]
+    wp = WorkPrecisionSet(prob, abstols, reltols, setups, names = wp_names,
+                          save_everystep = false,
+                          numruns = 100)
+
+    plt = @test_nowarn plot(wp)
+    @test plt[1][1][:x] ≈ getproperty(wp[1].errors, wp[1].error_estimate)
+    @test plt[1][2][:x] ≈ getproperty(wp[2].errors, wp[2].error_estimate)
+    @test plt[1][1][:label] == wp_names[1]
+    @test plt[1][2][:label] == wp_names[2]
+    @test_nowarn plot(wp, color = [1 2])
+    @test_nowarn plot(wp, color = :blue)
+    @test_throws ArgumentError plot(wp, view = :dt_convergence)
+
+    dts = 1.0 ./ 2.0 .^ ((1:length(reltols)) .+ 1)
+    setups = [Dict(:alg => Euler(), :dts => dts)
+              Dict(:alg => Heun(), :dts => dts)
+              Dict(:alg => Tsit5(), :dts => dts, :adaptive => false)
+              Dict(:alg => Tsit5())]
+    wp_names = ["Euler", "Heun", "Tsit5 fixed step", "Tsit5 adaptive"]
+    wp = WorkPrecisionSet(prob, abstols, reltols, setups, names = wp_names,
+                          save_everystep = false,
+                          numruns = 100)
+
+    plt = @test_nowarn plot(wp)
+    @test all(plt[1][i][:x] ≈ getproperty(wp[i].errors, wp[i].error_estimate) for i in 1:4)
+    @test all(plt[1][i][:label] == wp_names[i] for i in 1:4)
+
+    plt = @test_nowarn plot(wp, view = :dt_convergence, legend = :bottomright)
+    @test all(plt[1][i][:x] == plt[1][i + 3][:x] == dts == wp.setups[i][:dts] for i in 1:3)
+    @test all(plt[1][i + 3][:y] ≈ getproperty(wp[i].errors, wp[i].error_estimate) for i in 1:3)
+    @test all(startswith(plt[1][i + 3][:label], wp_names[i]) for i in 1:3)
+    @test_throws BoundsError plt[1][7]
+    @test_nowarn plot(wp, view = :dt_convergence, color = [:red :orange :green])
+    @test_nowarn plot(wp, view = :dt_convergence, color = :lightblue, title = "Δt Convergence")
+end
+
+
+@testset "SDE WorkPrecisionSet" begin
+    f_additive_iip(du, u, p, t) = @.(du=p[2] / sqrt(1 + t) - u / (2 * (1 + t)))
+    σ_additive_iip(du, u, p, t) = @.(du=p[1] * p[2] / sqrt(1 + t))
+    additive_analytic(u0, p, t, W) = @. u0 / sqrt(1 + t) + p[2] * (t + p[1] * W) / sqrt(1 + t)
+    ff_additive_iip = SDEFunction(f_additive_iip, σ_additive_iip, analytic = additive_analytic)
+    p = ([0.1; 0.1; 0.1; 0.1], [0.5; 0.25; 0.125; 0.1115])
+    prob_sde_additivesystem = SDEProblem(ff_additive_iip, [1.0; 1.0; 1.0; 1.0],
+                                         (0.0, 1.0), p)
+    prob = remake(prob_sde_additivesystem,tspan=(0.0,1.0))
+
+    reltols = 1.0 ./ 10.0 .^ (1:5)
+    abstols = reltols#[0.0 for i in eachindex(reltols)]
+    setups = [Dict(:alg=>SRIW1())
+              Dict(:alg=>EM(),:dts=>1.0./5.0.^((1:length(reltols)) .+ 1))
+              Dict(:alg=>RKMil(),:dts=>1.0./5.0.^((1:length(reltols)) .+ 1),:adaptive=>false)
+              Dict(:alg=>SRIW1(),:dts=>1.0./5.0.^((1:length(reltols)) .+ 1),:adaptive=>false)
+              Dict(:alg=>SRA1(),:dts=>1.0./5.0.^((1:length(reltols)) .+ 1),:adaptive=>false)
+              Dict(:alg=>SRA1())
+              ]
+    names = ["SRIW1","EM","RKMil","SRIW1 Fixed","SRA1 Fixed","SRA1"]
+    wp = WorkPrecisionSet(prob,abstols,reltols,setups;numruns=10,names=names,maxiters=1e7,error_estimate=:l2)
+
+    plt = @test_nowarn plot(wp)
+    for i in 1:length(names)
+        @test plt[1][i][:x] ≈ getproperty(wp[i].errors, wp[i].error_estimate)
+        @test plt[1][i][:label] == names[i]
     end
 end
-
-f_rode_lin_analytic = function (u₀, p, t)
-    u₀ * exp(sin(t))
-end
-
-tspan = (0.0, 10.0)
-prob = ODEProblem(ODEFunction(f_rode_lin, analytic = f_rode_lin_analytic), rand(10, 10),
-                  tspan)
-
-abstols = 1.0 ./ 10.0 .^ (3:8)
-reltols = 1.0 ./ 10.0 .^ (0:5)
-
-setups = [Dict(:alg => DP5())
-          Dict(:alg => Tsit5())]
-wp_names = ["DP5", "Tsit5"]
-wp = WorkPrecisionSet(prob, abstols, reltols, setups, names = wp_names,
-                      save_everystep = false,
-                      numruns = 100)
-
-plt = @test_nowarn plot(wp)
-@test plt[1][1][:x] ≈ getproperty(wp[1].errors, wp[1].error_estimate)
-@test plt[1][2][:x] ≈ getproperty(wp[2].errors, wp[2].error_estimate)
-@test plt[1][1][:label] == wp_names[1]
-@test plt[1][2][:label] == wp_names[2]
-@test_nowarn plot(wp, color = [1 2])
-@test_nowarn plot(wp, color = :blue)
-@test_throws ArgumentError plot(wp, view = :dt_convergence)
-
-dts = 1.0 ./ 2.0 .^ ((1:length(reltols)) .+ 1)
-setups = [Dict(:alg => Euler(), :dts => dts)
-          Dict(:alg => Heun(), :dts => dts)
-          Dict(:alg => Tsit5(), :dts => dts, :adaptive => false)
-          Dict(:alg => Tsit5())]
-wp_names = ["Euler", "Heun", "Tsit5 fixed step", "Tsit5 adaptive"]
-wp = WorkPrecisionSet(prob, abstols, reltols, setups, names = wp_names,
-                      save_everystep = false,
-                      numruns = 100)
-
-plt = @test_nowarn plot(wp)
-@test all(plt[1][i][:x] ≈ getproperty(wp[i].errors, wp[i].error_estimate) for i in 1:4)
-@test all(plt[1][i][:label] == wp_names[i] for i in 1:4)
-
-plt = @test_nowarn plot(wp, view = :dt_convergence, legend = :bottomright)
-@test all(plt[1][i][:x] == plt[1][i + 3][:x] == dts == wp.setups[i][:dts] for i in 1:3)
-@test all(plt[1][i + 3][:y] ≈ getproperty(wp[i].errors, wp[i].error_estimate) for i in 1:3)
-@test all(startswith(plt[1][i + 3][:label], wp_names[i]) for i in 1:3)
-@test_throws BoundsError plt[1][7]
-@test_nowarn plot(wp, view = :dt_convergence, color = [:red :orange :green])
-@test_nowarn plot(wp, view = :dt_convergence, color = :lightblue, title = "Δt Convergence")

--- a/test/plotrecipes_tests.jl
+++ b/test/plotrecipes_tests.jl
@@ -67,13 +67,6 @@ end
 
 
 @testset "SDE WorkPrecisionSet" begin
-    f_additive_iip(du, u, p, t) = @.(du=p[2] / sqrt(1 + t) - u / (2 * (1 + t)))
-    σ_additive_iip(du, u, p, t) = @.(du=p[1] * p[2] / sqrt(1 + t))
-    additive_analytic(u0, p, t, W) = @. u0 / sqrt(1 + t) + p[2] * (t + p[1] * W) / sqrt(1 + t)
-    ff_additive_iip = SDEFunction(f_additive_iip, σ_additive_iip, analytic = additive_analytic)
-    p = ([0.1; 0.1; 0.1; 0.1], [0.5; 0.25; 0.125; 0.1115])
-    prob_sde_additivesystem = SDEProblem(ff_additive_iip, [1.0; 1.0; 1.0; 1.0],
-                                         (0.0, 1.0), p)
     prob = remake(prob_sde_additivesystem,tspan=(0.0,1.0))
 
     reltols = 1.0 ./ 10.0 .^ (1:5)

--- a/test/plotrecipes_tests.jl
+++ b/test/plotrecipes_tests.jl
@@ -32,8 +32,8 @@ wp = WorkPrecisionSet(prob, abstols, reltols, setups, names = wp_names,
                       numruns = 100)
 
 plt = @test_nowarn plot(wp)
-@test plt[1][1][:x] ≈ wp[1].errors
-@test plt[1][2][:x] ≈ wp[2].errors
+@test plt[1][1][:x] ≈ getproperty(wp[1].errors, wp[1].error_estimate)
+@test plt[1][2][:x] ≈ getproperty(wp[2].errors, wp[2].error_estimate)
 @test plt[1][1][:label] == wp_names[1]
 @test plt[1][2][:label] == wp_names[2]
 @test_nowarn plot(wp, color = [1 2])
@@ -51,12 +51,12 @@ wp = WorkPrecisionSet(prob, abstols, reltols, setups, names = wp_names,
                       numruns = 100)
 
 plt = @test_nowarn plot(wp)
-@test all(plt[1][i][:x] ≈ wp[i].errors for i in 1:4)
+@test all(plt[1][i][:x] ≈ getproperty(wp[i].errors, wp[i].error_estimate) for i in 1:4)
 @test all(plt[1][i][:label] == wp_names[i] for i in 1:4)
 
 plt = @test_nowarn plot(wp, view = :dt_convergence, legend = :bottomright)
 @test all(plt[1][i][:x] == plt[1][i + 3][:x] == dts == wp.setups[i][:dts] for i in 1:3)
-@test all(plt[1][i + 3][:y] ≈ wp[i].errors for i in 1:3)
+@test all(plt[1][i + 3][:y] ≈ getproperty(wp[i].errors, wp[i].error_estimate) for i in 1:3)
 @test all(startswith(plt[1][i + 3][:label], wp_names[i]) for i in 1:3)
 @test_throws BoundsError plt[1][7]
 @test_nowarn plot(wp, view = :dt_convergence, color = [:red :orange :green])


### PR DESCRIPTION
Implements #125

For convenience I used StructArrays.jl as I thought being able to do `errors.l2` would be nice, but this introduces a new dependency which might not be ideal. Also, to get things to work I transformed the `Dict` into a `NamedTuple`, which might also be an unwanted change. I could change this if a different implementation is preferred.

- For ODEProblem and BVProblem, `WorkPrecision.errors` contains all the computed errors returned by `appxtrue`
- For NonlinearProblem, `WorkPrecision.errors` is a StructArray which contains just a single key (the passed `error_estimate`)
- For AbstractRODEProblem, I left everything as before and `WorkPrecision.errors` contains just a vector. :warning: **This is probably an issue! The plot recipe most likely fails here now!** :warning: I didn't fix this as I never worked with RODEs, so if someone else could write a test that would probably be best.