### PR TITLE
Update the plotting recipe to flexibly plot some x against some y

### DIFF
--- a/src/DiffEqDevTools.jl
+++ b/src/DiffEqDevTools.jl
@@ -23,6 +23,8 @@ const WEAK_TIMESERIES_ERRORS = Set([:weak_l2, :weak_l∞])
 const WEAK_DENSE_ERRORS = Set([:weak_L2, :weak_L∞])
 const WEAK_ERRORS = union(Set([:weak_final]),
                           WEAK_TIMESERIES_ERRORS, WEAK_DENSE_ERRORS)
+const ALL_ERRORS = union([:final],
+    TIMESERIES_ERRORS, DENSE_ERRORS, WEAK_TIMESERIES_ERRORS, WEAK_DENSE_ERRORS, WEAK_ERRORS)
 
 include("benchmark.jl")
 include("convergence.jl")

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -47,7 +47,7 @@ function get_val_from_wp(wp::WorkPrecision, key::Symbol)
         return wp.times
     elseif key == :dts
         return wp.dts
-    elseif key in propertynames(wp.stats[1])
+    elseif !isnothing(wp.stats) && key in propertynames(wp.stats[1])
         return [getproperty(s, key) for s in wp.stats]
     elseif key in propertynames(wp.errors)
         return getproperty(wp.errors, key)

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -38,23 +38,57 @@ end
     return errors, wp.times
 end
 
-@recipe function f(wp_set::WorkPrecisionSet; view = :benchmark, color = nothing)
+function get_val_from_wp(wp::WorkPrecision, key::Symbol)
+    if key == :abstols
+        return wp.abstols
+    elseif key == :reltols
+        return wp.reltols
+    elseif key == :times
+        return wp.times
+    elseif key == :dts
+        return wp.dts
+    elseif key in propertynames(wp.stats[1])
+        return [getproperty(s, key) for s in wp.stats]
+    elseif key in propertynames(wp.errors)
+        return getproperty(wp.errors, key)
+    else
+        throw(ArgumentError("Key $key does not specify a valid property of WorkPrecision"))
+    end
+end
+
+function key_to_label(key::Symbol)
+    if key == :abstols
+        return "Absolute tolerance"
+    elseif key == :reltols
+        return "Relative tolerance"
+    elseif key == :times
+        return "Time (s)"
+    elseif key == :dts
+        return "Δt"
+    elseif key in ALL_ERRORS
+        return "Error ($key)"
+    else
+        return key
+    end
+end
+
+@recipe function f(wp_set::WorkPrecisionSet;
+    x::Symbol = wp_set.error_estimate,
+    y::Symbol = :times,
+    view = :benchmark,
+    color = nothing)
     if view == :benchmark
         seriestype --> :path
         linewidth --> 3
-        yguide --> "Time (s)"
-        xguide --> "Error ($(wp_set.error_estimate))"
         xscale --> :log10
         yscale --> :log10
         markershape --> :auto
-        errors = Vector{Any}(undef, 0)
-        times = Vector{Any}(undef, 0)
-        for i in 1:length(wp_set)
-            push!(errors, getproperty(wp_set[i].errors, wp_set.error_estimate))
-            push!(times, wp_set[i].times)
-        end
+        xs = [get_val_from_wp(wp, x) for wp in wp_set.wps]
+        ys = [get_val_from_wp(wp, y) for wp in wp_set.wps]
+        xguide --> key_to_label(x)
+        yguide --> key_to_label(y)
         label --> reshape(wp_set.names, 1, length(wp_set))
-        return errors, times
+        return xs, ys
     elseif view == :dt_convergence
         idts = filter(i -> haskey(wp_set.setups[i], :dts), 1:length(wp_set))
         length(idts) > 0 ||
@@ -90,7 +124,7 @@ end
             seriestype --> :path
             linewidth --> 3
             color --> color
-            yguide --> "Error"
+            yguide --> "Error ($(wp_set.error_estimate))"
             xguide --> "Δt"
             xscale --> :log10
             yscale --> :log10

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -67,6 +67,29 @@ function key_to_label(key::Symbol)
         return "Δt"
     elseif key in ALL_ERRORS
         return "Error ($key)"
+    # Some DEStats cases copied from SciMLBase: src/solutions/ode_solutions.jl#L43-L56
+    elseif key == :nf
+        return "Number of function evaluations"
+    elseif key == :nf2
+        return "Number of function 2 evaluations"
+    elseif key == :nw
+        return "Number of W matrix evaluations"
+    elseif key == :nsolve
+        return "Number of linear solves"
+    elseif key == :njacs
+        return "Number of Jacobians created"
+    elseif key == :nnonliniter
+        return "Number of nonlinear solver iterations"
+    elseif key == :nnonlinconvfail
+        return "Number of nonlinear solver convergence failures"
+    elseif key == :ncondition
+        return "Number of rootfind condition calls"
+    elseif key == :naccept
+        return "Number of accepted steps"
+    elseif key == :nreject
+        return "Number of rejected steps"
+    elseif key == :maxeig
+            return "Maximum eigenvalue recorded"
     else
         return key
     end

--- a/test/plotrecipes_tests.jl
+++ b/test/plotrecipes_tests.jl
@@ -42,6 +42,11 @@ gr()
     @test_nowarn plot(wp, color = :blue)
     @test_throws ArgumentError plot(wp, view = :dt_convergence)
 
+    @test_nowarn plot(wp, x = :abstols, y = :final)
+    @test_nowarn plot(wp, x = :reltols, y = :nf)
+    @test_nowarn plot(wp, x = :naccept, y = :nreject)
+    @test_throws ArgumentError plot(wp, x = :notakey, y = :final)
+
     dts = 1.0 ./ 2.0 .^ ((1:length(reltols)) .+ 1)
     setups = [Dict(:alg => Euler(), :dts => dts)
               Dict(:alg => Heun(), :dts => dts)
@@ -55,6 +60,8 @@ gr()
     plt = @test_nowarn plot(wp)
     @test all(plt[1][i][:x] ≈ getproperty(wp[i].errors, wp[i].error_estimate) for i in 1:4)
     @test all(plt[1][i][:label] == wp_names[i] for i in 1:4)
+
+    @test_nowarn plot(wp, x = :dts, y = :final)
 
     plt = @test_nowarn plot(wp, view = :dt_convergence, legend = :bottomright)
     @test all(plt[1][i][:x] == plt[1][i + 3][:x] == dts == wp.setups[i][:dts] for i in 1:3)


### PR DESCRIPTION
Implements #128

Code snipped to try this out:
```julia
using TestEnv
TestEnv.activate()

using OrdinaryDiffEq, DiffEqDevTools, Plots

# dummy ODE work-precision diagram
f_rode_lin = function (du, u, p, t)
    @inbounds for i in eachindex(u)
        du[i] = cos(t) * u[i]
    end
end

f_rode_lin_analytic = function (u₀, p, t)
    u₀ * exp(sin(t))
end

tspan = (0.0, 10.0)
prob = ODEProblem(ODEFunction(f_rode_lin, analytic = f_rode_lin_analytic), rand(10, 10),
    tspan)

abstols = 1.0 ./ 10.0 .^ (3:8)
reltols = 1.0 ./ 10.0 .^ (0:5)

setups = [Dict(:alg => DP5())
          Dict(:alg => Tsit5())]
wp_names = ["DP5", "Tsit5"]
wps = WorkPrecisionSet(prob, abstols, reltols, setups; names = wp_names, error_estimate=:l2)

plot(wps)
plot(wps, y=:final)
plot(wps, x=:l2, y=:final)
plot(wps, x=:abstols, y=:final)
plot(wps, x=:nf, y=:final)
```