### PR TITLE
Fix another deprecationwarning in `appxtrue(, ::TestSolution)`

### DIFF
--- a/src/test_solution.jl
+++ b/src/test_solution.jl
@@ -41,7 +41,7 @@ calculated.
 """
 function appxtrue(sol::AbstractODESolution, sol2::TestSolution)
     if sol2.u == nothing && hasinterp(sol2)
-        _sol = TestSolution(sol.t, sol2(sol.t), sol2)
+        _sol = TestSolution(sol.t, sol2(sol.t).u, sol2)
     else
         _sol = sol2
     end

--- a/test/ode_appxtrue_tests.jl
+++ b/test/ode_appxtrue_tests.jl
@@ -18,7 +18,7 @@ test_sol = TestSolution(sol2)
 errsol2 = appxtrue(sol4, test_sol)
 
 sol5 = solve(prob, Euler(); dt = 1 // 2^(4))
-test_sol = TestSolution(sol2.t, sol2[end])
+test_sol = TestSolution(sol2.t, sol2.u[end])
 errsol3 = appxtrue(sol5, test_sol)
 
 @test errsol1.errors[:L2] ≈ 0.018865798306718855


### PR DESCRIPTION
`appxtrue(, ::TestSolution)` was still throwing deprecation warnings, for example in these lines in the package tests:
https://github.com/SciML/DiffEqDevTools.jl/blob/0ae7b4f9ae98e1f77f3bc2b8fe35d1bacf1028ba/test/ode_appxtrue_tests.jl#L18
https://github.com/SciML/DiffEqDevTools.jl/blob/0ae7b4f9ae98e1f77f3bc2b8fe35d1bacf1028ba/test/ode_appxtrue_tests.jl#L22
Tis comes from here
https://github.com/SciML/DiffEqDevTools.jl/blob/0ae7b4f9ae98e1f77f3bc2b8fe35d1bacf1028ba/src/test_solution.jl#L22
with `u` being `sol2(sol.t)` from here:
https://github.com/SciML/DiffEqDevTools.jl/blob/0ae7b4f9ae98e1f77f3bc2b8fe35d1bacf1028ba/src/test_solution.jl#L44
Just adding `.u` fixes this.