### PR TITLE
Remove type annotations of keyword arguments in plot recipes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqDevTools"
 uuid = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.44.2"
+version = "2.44.3"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -96,8 +96,8 @@ function key_to_label(key::Symbol)
 end
 
 @recipe function f(wp_set::WorkPrecisionSet;
-        x::Symbol = wp_set.error_estimate,
-        y::Symbol = :times,
+        x = wp_set.error_estimate,
+        y = :times,
         view = :benchmark,
         color = nothing)
     if view == :benchmark


### PR DESCRIPTION
They are currently not supported and cause warnings, e.g., in https://github.com/SciML/DelayDiffEq.jl/actions/runs/8744064205/job/23996107103?pr=288#step:6:458.