### PR TITLE
Fixed L2 error for complex valued problems

### DIFF
--- a/src/test_solution.jl
+++ b/src/test_solution.jl
@@ -51,7 +51,7 @@ function appxtrue(sol::AbstractODESolution, sol2::TestSolution)
     if _sol.dense
         timeseries_analytic = _sol(sol.t)
         errors[:l∞] = maximum(vecvecapply((x) -> abs.(x), sol - timeseries_analytic))
-        errors[:l2] = sqrt(recursive_mean(vecvecapply((x) -> float(x) .^ 2,
+        errors[:l2] = sqrt(recursive_mean(vecvecapply((x) -> conj.(float(x)) .* float(x),
             sol - timeseries_analytic)))
         densetimes = collect(range(sol.t[1], stop = sol.t[end], length = 100))
         interp_u = sol(densetimes)
@@ -59,7 +59,7 @@ function appxtrue(sol::AbstractODESolution, sol2::TestSolution)
         interp_errors = Dict(
             :L∞ => maximum(vecvecapply((x) -> abs.(x),
                 interp_u - interp_analytic)),
-            :L2 => sqrt(recursive_mean(vecvecapply((x) -> float(x) .^ 2,
+            :L2 => sqrt(recursive_mean(vecvecapply((x) -> conj.(float(x)) .* float(x),
                 interp_u -
                 interp_analytic))))
         errors = merge(errors, interp_errors)
@@ -67,7 +67,8 @@ function appxtrue(sol::AbstractODESolution, sol2::TestSolution)
         timeseries_analytic = sol2.u
         if sol.t == sol2.t
             errors[:l∞] = maximum(vecvecapply((x) -> abs.(x), sol - timeseries_analytic))
-            errors[:l2] = sqrt(recursive_mean(vecvecapply((x) -> float(x) .^ 2,
+            errors[:l2] = sqrt(recursive_mean(vecvecapply(
+                (x) -> conj.(float(x)) .* float(x),
                 sol - timeseries_analytic)))
         end
     end
@@ -87,7 +88,7 @@ function appxtrue(sol::AbstractODESolution, sol2::AbstractODESolution;
     if sol2.dense
         timeseries_analytic = sol2(sol.t)
         errors[:l∞] = maximum(vecvecapply((x) -> abs.(x), sol - timeseries_analytic))
-        errors[:l2] = sqrt(recursive_mean(vecvecapply((x) -> float(x) .^ 2,
+        errors[:l2] = sqrt(recursive_mean(vecvecapply((x) -> conj.(float(x)) .* float(x),
             sol - timeseries_analytic)))
         if dense_errors
             densetimes = collect(range(sol.t[1], stop = sol.t[end], length = 100))
@@ -96,7 +97,7 @@ function appxtrue(sol::AbstractODESolution, sol2::AbstractODESolution;
             interp_errors = Dict(
                 :L∞ => maximum(vecvecapply((x) -> abs.(x),
                     interp_u - interp_analytic)),
-                :L2 => sqrt(recursive_mean(vecvecapply((x) -> float(x) .^ 2,
+                :L2 => sqrt(recursive_mean(vecvecapply((x) -> conj.(float(x)) .* float(x),
                     interp_u -
                     interp_analytic))))
             errors = merge(errors, interp_errors)
@@ -105,7 +106,8 @@ function appxtrue(sol::AbstractODESolution, sol2::AbstractODESolution;
         timeseries_analytic = sol2.u
         if timeseries_errors && sol.t == sol2.t
             errors[:l∞] = maximum(vecvecapply((x) -> abs.(x), sol - timeseries_analytic))
-            errors[:l2] = sqrt(recursive_mean(vecvecapply((x) -> float(x) .^ 2,
+            errors[:l2] = sqrt(recursive_mean(vecvecapply(
+                (x) -> conj.(float(x)) .* float(x),
                 sol - timeseries_analytic)))
         end
     end


### PR DESCRIPTION
Currently, L2 error calculations in DiffEqDevTools.jl use 
`sqrt(recursive_mean(vecvecapply((x) -> float(x) .^ 2, sol - timeseries_analytic)))`
the issue is if the solution is complex this returns the sum of the square of the complex differences instead of the sum of the absolute value squared (i.e. the L2 error should never be complex). For example,
```
wp = WorkPrecisionSet(prob,abstols,reltols,setups,1//2^(10);numruns=5,names=names,maxiters=1e7,error_estimate=:l2,appxsol_setup=Dict(:alg=>RKMilGeneral(;ii_approx=IICommutative())))
plot(wp)
```
leads to the error:
`isless(::ComplexF64, ::ComplexF64)`

I corrected this by replacing `x .^2` with `conj.(x).*x`:
`errors[:l2] = sqrt(recursive_mean(vecvecapply((x) -> conj.(float(x)) .* float(x), sol - timeseries_analytic)))`

I checked using benchmark tools that this has approximately the same runtime as the line replaced.
```
julia> function f1!(x)
           return float(x) .^ 2
       end
f1! (generic function with 1 method)

julia> function f2!(x)
           return float(abs.(x)) .^ 2
       end
f2! (generic function with 1 method)

julia> function f3!(x)
           return conj.(float(x)).*float(x)
       end
f3! (generic function with 1 method)

``` 
For `vec = rand(ComplexF64, 1000)`, I found the following using benchmark tools:
<img width="730" alt="complexvecbenchmark" src="https://github.com/user-attachments/assets/fc4ebdf9-7880-4035-b951-847744e49299">
For `vec2 = rand(Float64, 1000)`, I found the following using benchmark tools:
<img width="756" alt="float64vecbenchmark" src="https://github.com/user-attachments/assets/053cabe3-4ad9-4732-9799-392c34f7ddc9">

## Checklist
- [ ] Appropriate tests were added (I think this change is too minor to necessitate new unit test.)
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
