### PR TITLE
fix typo in docstring of `imaginary_stability_interval`

### DIFF
--- a/src/tableau_info.jl
+++ b/src/tableau_info.jl
@@ -94,7 +94,7 @@ function imaginary_stability_interval(tab::ODERKTableau;
 end
 
 """
-    imaginary_stability_interval(alg::ODERKTableau;
+    imaginary_stability_interval(alg::AbstractODEAlgorithm;
                                  initial_guess = 20.0)
 
 Calculates the length of the imaginary stability interval, i.e.,


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
