### PR TITLE
Remove outdated Julia v1.8 version check

### DIFF
--- a/test/analyticless_convergence_tests.jl
+++ b/test/analyticless_convergence_tests.jl
@@ -14,9 +14,7 @@ test_setup = Dict(:alg => Vern9(), :reltol => 1e-25, :abstol => 1e-25)
 sim1 = analyticless_test_convergence(dts, prob, Tsit5(), test_setup)
 sim2 = analyticless_test_convergence(dts, prob, Vern9(), test_setup)
 
-if VERSION >= v"1.8"
-    @test_throws "No analytical solution set." test_convergence(dts, prob, Tsit5())
-end
+@test_throws "No analytical solution set." test_convergence(dts, prob, Tsit5())
 
 @test abs(sim1.𝒪est[:final] - 5) < 0.2
 @test abs(sim2.𝒪est[:final] - 9) < 0.2


### PR DESCRIPTION
## Summary
Since Julia v1.10 is now the LTS, the version-gated test for v1.8 is no longer needed.

## Changes
- Removed @test_throws check that was conditional on VERSION >= v"1.8" in test/analyticless_convergence_tests.jl

## Test plan
- [ ] Tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)