### PR TITLE
Version bump to 2.50.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqDevTools"
 uuid = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.49.0"
+version = "2.50.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"


### PR DESCRIPTION
## Version Bump

Bumping version from 2.49.0 to 2.50.0 to prepare for release.

### Changes since last release

Since v2.49.0, the following changes have been merged:
- #164: Fix minimum version bound for RootedTrees

### Registration Command

After merging, register with:

@JuliaRegistrator register

cc @ChrisRackauckas