### PR TITLE
Fix bugs found by JET static analysis

### DIFF
--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -33,8 +33,8 @@ mutable struct ShootoutSet
 end
 
 function ode_shootout(args...; kwargs...)
-    @warn("ode_shootout is deprecated. Use ShootOut instead")
-    ShootOut(args...; kwargs...)
+    @warn("ode_shootout is deprecated. Use Shootout instead")
+    Shootout(args...; kwargs...)
 end
 
 function Shootout(
@@ -348,8 +348,8 @@ function WorkPrecision(prob::AbstractBVProblem, alg, abstols, reltols, dts = not
                     end
                 else
                     errors[i] = Dict{Symbol, Float64}()
-                    for err in keys(errsol.errors)
-                        errors[i][err] = mean(errsol.errors[err])
+                    for err in keys(sol.errors)
+                        errors[i][err] = mean(sol.errors[err])
                     end
                 end
 

--- a/src/test_solution.jl
+++ b/src/test_solution.jl
@@ -122,6 +122,6 @@ function appxtrue(sim::EnsembleSolution, appx_setup; kwargs...)
         _new_sols[i] = appxtrue(sim.u[i], true_sol)
     end
     new_sols = convert(Vector{typeof(_new_sols[1])}, _new_sols)
-    calculate_ensemble_errors(new_sols; converged = sim.converged,
+    DiffEqBase.calculate_ensemble_errors(new_sols; converged = sim.converged,
         elapsedTime = sim.elapsedTime, kwargs...)
 end


### PR DESCRIPTION
## Summary

This PR fixes 3 bugs discovered by running JET.jl static analysis (`JET.report_package("DiffEqDevTools")`):

- **Fix typo in deprecated function**: `ShootOut` → `Shootout` in `ode_shootout` function (src/benchmark.jl:37)
- **Fix undefined variable bug**: When `appxsol === nothing` in the BVP `WorkPrecision` function, the code incorrectly referenced `errsol.errors` which doesn't exist - changed to `sol.errors` to match the ODE version (src/benchmark.jl:351-352)  
- **Fix unqualified function reference**: `calculate_ensemble_errors` → `DiffEqBase.calculate_ensemble_errors` (src/test_solution.jl:125)

## JET Analysis Results

Before this PR: 38 possible errors
After this PR: 35 possible errors (remaining are in upstream packages or false positives)

## Test plan

- [x] All existing tests pass (`Pkg.test()` completed successfully)
- [x] Re-ran JET analysis to confirm the 3 issues are fixed

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)