### PR TITLE
Documentation improvements: Fix typo and update URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Join the chat at https://gitter.im/JuliaDiffEq/Lobby](https://badges.gitter.im/JuliaDiffEq/Lobby.svg)](https://gitter.im/JuliaDiffEq/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://github.com/SciML/DiffEqDevTools.jl/workflows/CI/badge.svg)](https://github.com/SciML/DiffEqDevTools.jl/actions?query=workflow%3ACI)
-[![Coverage Status](https://coveralls.io/repos/github/JuliaDiffEq/DiffEqDevTools.jl/badge.svg)](https://coveralls.io/github/JuliaDiffEq/DiffEqDevTools.jl)
-[![codecov.io](http://codecov.io/github/ChrisRackauckas/DevToolsDiffEq.jl/coverage.svg?branch=master)](http://codecov.io/github/ChrisRackauckas/DevToolsDiffEq.jl?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/SciML/DiffEqDevTools.jl/badge.svg)](https://coveralls.io/github/SciML/DiffEqDevTools.jl)
+[![codecov.io](http://codecov.io/github/SciML/DiffEqDevTools.jl/coverage.svg?branch=master)](http://codecov.io/github/SciML/DiffEqDevTools.jl?branch=master)
 
 DiffEqDevTools.jl is a component package in the DifferentialEquations ecosystem. It holds the
 convergence testing, benchmarking, and error approximation functionality which is
 used by the other component packages in order to test for correctness. Users interested in using this
-functionality should check out [DifferentialEquations.jl](https://github.com/JuliaDiffEq/DifferentialEquations.jl)
+functionality should check out [DifferentialEquations.jl](https://github.com/SciML/DifferentialEquations.jl)

--- a/src/convergence.jl
+++ b/src/convergence.jl
@@ -247,7 +247,7 @@ end
 """
 length(simres::ConvergenceSimulation)
 
-Returns the number of simultations in the Convergence Simulation
+Returns the number of simulations in the Convergence Simulation
 """
 Base.length(sim::ConvergenceSimulation) = sim.N
 Base.getindex(sim::ConvergenceSimulation, i::Int) = sim.solutions[i]


### PR DESCRIPTION
## Summary

This PR improves the documentation by fixing a typo and updating outdated URLs:

- **Fix typo in `src/convergence.jl`**: Changed "simultations" to "simulations" in the docstring for `length(::ConvergenceSimulation)`
- **Update README.md badge URLs**: Updated coverage badge URLs to use the `SciML` organization instead of the outdated `JuliaDiffEq` and `ChrisRackauckas` repositories
- **Update DifferentialEquations.jl link**: Changed the link to point to `SciML/DifferentialEquations.jl` instead of `JuliaDiffEq/DifferentialEquations.jl`

## Test plan

- [x] Documentation changes only - no code logic modified
- [x] Verified URLs point to correct repositories
- [x] No functional changes to test

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)