### PR TITLE
Interface compatibility: Fix type genericity for SDE noise generation

### DIFF
--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -495,12 +495,13 @@ end
 
 @def error_calculation begin
     if !DiffEqBase.has_analytic(prob.f)
+        T = eltype(prob.u0)
         t = prob.tspan[1]:test_dt:prob.tspan[2]
-        brownian_values = cumsum([[zeros(size(prob.u0))];
-                                  [sqrt(test_dt) * randn(size(prob.u0))
+        brownian_values = cumsum([[zeros(T, size(prob.u0))];
+                                  [sqrt(test_dt) * randn(T, size(prob.u0))
                                    for i in 1:(length(t) - 1)]])
-        brownian_values2 = cumsum([[zeros(size(prob.u0))];
-                                   [sqrt(test_dt) * randn(size(prob.u0))
+        brownian_values2 = cumsum([[zeros(T, size(prob.u0))];
+                                   [sqrt(test_dt) * randn(T, size(prob.u0))
                                     for i in 1:(length(t) - 1)]])
         np = NoiseGrid(t, brownian_values, brownian_values2)
         _prob = remake(prob, noise = np)
@@ -794,10 +795,11 @@ function get_sample_errors(prob::AbstractRODEProblem, setup, test_dt = nothing;
     if DiffEqBase.has_analytic(prob.f)
         analytical_mean_end = mean(1:sample_error_runs) do i
             _dt = prob.tspan[2] - prob.tspan[1]
+            T = eltype(prob.u0)
             if prob.u0 isa Number
-                W = sqrt(_dt) * randn()
+                W = sqrt(_dt) * randn(T)
             else
-                W = sqrt(_dt) * randn(size(prob.u0))
+                W = sqrt(_dt) * randn(T, size(prob.u0))
             end
             prob.f.analytic(prob.u0, prob.p, prob.tspan[2], W)
         end

--- a/src/convergence.jl
+++ b/src/convergence.jl
@@ -124,21 +124,22 @@ function analyticless_test_convergence(dts::AbstractArray,
         end
         t = prob.tspan[1]:test_dt:prob.tspan[2]
         if use_noise_grid
+            T = eltype(prob.u0)
             if prob.noise_rate_prototype === nothing
-                brownian_values = cumsum([[zeros(size(prob.u0))];
-                                          [sqrt(test_dt) * randn(size(prob.u0))
+                brownian_values = cumsum([[zeros(T, size(prob.u0))];
+                                          [sqrt(test_dt) * randn(T, size(prob.u0))
                                            for i in 1:(length(t) - 1)]])
-                brownian_values2 = cumsum([[zeros(size(prob.u0))];
-                                           [sqrt(test_dt) * randn(size(prob.u0))
+                brownian_values2 = cumsum([[zeros(T, size(prob.u0))];
+                                           [sqrt(test_dt) * randn(T, size(prob.u0))
                                             for i in 1:(length(t) - 1)]])
             else
-                brownian_values = cumsum([[zeros(size(prob.noise_rate_prototype, 2))];
+                brownian_values = cumsum([[zeros(T, size(prob.noise_rate_prototype, 2))];
                                           [sqrt(test_dt) *
-                                           randn(size(prob.noise_rate_prototype, 2))
+                                           randn(T, size(prob.noise_rate_prototype, 2))
                                            for i in 1:(length(t) - 1)]])
-                brownian_values2 = cumsum([[zeros(size(prob.noise_rate_prototype, 2))];
+                brownian_values2 = cumsum([[zeros(T, size(prob.noise_rate_prototype, 2))];
                                            [sqrt(test_dt) *
-                                            randn(size(prob.noise_rate_prototype, 2))
+                                            randn(T, size(prob.noise_rate_prototype, 2))
                                             for i in 1:(length(t) - 1)]])
             end
             np = NoiseGrid(t, brownian_values, brownian_values2)


### PR DESCRIPTION
## Summary

- Fix `zeros()` and `randn()` calls in SDE functions to respect `eltype(prob.u0)` instead of defaulting to Float64
- Enables BigFloat-precision SDE convergence testing
- Improves adherence to SciML's array/number interface

## Changes

In `src/convergence.jl` and `src/benchmark.jl`:
- Extract `T = eltype(prob.u0)` for type inference
- Use `zeros(T, size(prob.u0))` instead of `zeros(size(prob.u0))`
- Use `randn(T, size(prob.u0))` instead of `randn(size(prob.u0))`

## Interface Testing Performed

1. **BigFloat support**: Verified that tableaus work with `constructEuler(BigFloat)` and `stability_region` preserves precision
2. **JLArrays testing**: Confirmed the package doesn't use problematic scalar indexing patterns
3. **All existing tests pass**: Full test suite completed successfully

## Test plan

- [x] Run `Pkg.test()` - all tests pass
- [x] Verify BigFloat precision is maintained in noise generation
- [x] Check that existing Float64 behavior is unchanged

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)