### PR TITLE
Improve static analysis and type stability

### DIFF
--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -91,7 +91,7 @@ function key_to_label(key::Symbol)
     elseif key == :maxeig
         return "Maximum eigenvalue recorded"
     else
-        return key
+        return String(key)
     end
 end
 

--- a/src/tableau_info.jl
+++ b/src/tableau_info.jl
@@ -18,7 +18,7 @@ r(z) = 1 + z bᵀ(I - zA)⁻¹ e
 ```
 where e denotes a vector of ones.
 """
-function stability_region(z, tab::ODERKTableau; embedded = false)
+function stability_region(z::Number, tab::ODERKTableau; embedded::Bool = false)
     A, c = tab.A, tab.c
     b = embedded ? tab.αEEst : tab.α
     e = ones(eltype(A), length(b))
@@ -50,7 +50,7 @@ julia> stability_region(nextfloat(typemin(Float64)), ImplicitEuler())
 0.0
 ```
 """
-function stability_region(z, alg::AbstractODEAlgorithm)
+function stability_region(z::Number, alg::AbstractODEAlgorithm)
     u0 = one(z)
     tspan = (zero(real(z)), one(real(z)))
     ode = ODEProblem{false}((u, p, t) -> z * u, u0, tspan)
@@ -111,9 +111,9 @@ function imaginary_stability_interval(alg::AbstractODEAlgorithm;
     sol.zero[1]
 end
 
-function RootedTrees.residual_order_condition(tab::ODERKTableau, order::Int,
+function RootedTrees.residual_order_condition(tab::ODERKTableau, order::Integer,
         reducer = nothing, mapper = x -> x^2;
-        embedded = false)
+        embedded::Bool = false)
     A, c = tab.A, tab.c
     b = embedded ? tab.αEEst : tab.α
     if reducer === nothing
@@ -130,7 +130,7 @@ end
 
 isfsal(tab::ExplicitRKTableau) = tab.fsal
 isfsal(::ImplicitRKTableau) = nothing
-function check_tableau(tab; tol = 10eps(1.0))
+function check_tableau(tab::ODERKTableau; tol::Real = 10eps(1.0))
     order = all(i -> residual_order_condition(tab, i, +, abs) < tol, 1:(tab.order))
     if !order
         error("Tableau's order is not correct.")

--- a/src/test_solution.jl
+++ b/src/test_solution.jl
@@ -82,7 +82,7 @@ errors for sol. If sol2 has no interpolant, only the final error is
 calculated.
 """
 function appxtrue(sol::AbstractODESolution, sol2::AbstractODESolution;
-        timeseries_errors = sol2.dense, dense_errors = sol2.dense)
+        timeseries_errors::Bool = sol2.dense, dense_errors::Bool = sol2.dense)
     errors = Dict(:final => recursive_mean(abs.(sol.u[end] - sol2.u[end])))
     if sol2.dense
         timeseries_analytic = sol2(sol.t)


### PR DESCRIPTION
## Summary
- Fix type instability in `key_to_label`: now returns `String` consistently instead of `Union{String, Symbol}`
- Add conservative type annotations to improve static analysis compatibility
- All changes verified with `@inferred` and full test suite passes

## Changes

### Type instability fix
- **key_to_label**: Changed the fallback return from `key` (Symbol) to `String(key)` so the function always returns `String`

### Conservative type annotations added
- `stability_region(z::Number, tab::ODERKTableau; embedded::Bool = false)`
- `stability_region(z::Number, alg::AbstractODEAlgorithm)`  
- `residual_order_condition(tab::ODERKTableau, order::Integer, ...; embedded::Bool = false)`
- `check_tableau(tab::ODERKTableau; tol::Real = 10eps(1.0))`
- `appxtrue(...; timeseries_errors::Bool = ..., dense_errors::Bool = ...)`

These annotations:
- Use abstract types (`Number`, `Integer`, `Real`, `Bool`) to preserve flexibility
- Match the existing patterns and dispatches in the codebase
- Help catch type errors at compile time
- Improve static analysis compatibility for tools like JET.jl

## Test plan
- [x] Verified type stability with `@inferred` for modified functions
- [x] Full test suite passes (`Pkg.test()`)
- [x] Package loads and precompiles correctly

## JET Analysis
Ran JET.report_package on the codebase. Most issues are in upstream dependencies (DiffEqBase, SciMLBase). The package's own functions like `stability_region`, `check_tableau`, `hasinterp`, and `key_to_label` are now type stable.

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)